### PR TITLE
change the format of the diagnostic counts to avoid pluralizing because "informations" looks weird

### DIFF
--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -930,7 +930,7 @@ function reportDiagnosticsAsText(
     console.info(
         `${errorCount.toString()} ${errorCount === 1 ? 'error' : 'errors'}, ` +
             `${warningCount.toString()} ${warningCount === 1 ? 'warning' : 'warnings'}, ` +
-            `${informationCount.toString()} ${informationCount === 1 ? 'information' : 'informations'} `
+            `${informationCount.toString()} ${informationCount === 1 ? 'note' : 'notes'} `
     );
 
     return {


### PR DESCRIPTION
fixes #58 