### PR TITLE
remove `typing.Callable` deprecation since `Callable` is not a collection

### DIFF
--- a/packages/pyright-internal/src/analyzer/deprecatedSymbols.ts
+++ b/packages/pyright-internal/src/analyzer/deprecatedSymbols.ts
@@ -304,13 +304,4 @@ export const deprecatedAliases = new Map<string, DeprecatedForm>([
 export const deprecatedSpecialForms = new Map<string, DeprecatedForm>([
     ['Optional', { version: PythonVersion.V3_10, fullName: 'typing.Optional', replacementText: '| None' }],
     ['Union', { version: PythonVersion.V3_10, fullName: 'typing.Union', replacementText: '|' }],
-    [
-        'Callable',
-        {
-            version: PythonVersion.V3_9,
-            fullName: 'typing.Callable',
-            replacementText: 'collections.abc.Callable',
-            typingImportOnly: true,
-        },
-    ],
 ]);

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -526,11 +526,11 @@ test('Deprecated1', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_9;
     const analysisResults5 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
-    TestUtils.validateResults(analysisResults5, 0, 0, 0, undefined, undefined, 45);
+    TestUtils.validateResults(analysisResults5, 0, 0, 0, undefined, undefined, 44);
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const analysisResults6 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
-    TestUtils.validateResults(analysisResults6, 0, 0, 0, undefined, undefined, 49);
+    TestUtils.validateResults(analysisResults6, 0, 0, 0, undefined, undefined, 48);
 
     // Now change reportDeprecated to emit an error.
     configOptions.diagnosticRuleSet.reportDeprecated = 'error';
@@ -541,11 +541,11 @@ test('Deprecated1', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_9;
     const analysisResults8 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
-    TestUtils.validateResults(analysisResults8, 45, 0, 0, undefined, undefined, 0);
+    TestUtils.validateResults(analysisResults8, 44, 0, 0, undefined, undefined, 0);
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const analysisResults9 = TestUtils.typeAnalyzeSampleFiles(['deprecated1.py'], configOptions);
-    TestUtils.validateResults(analysisResults9, 49, 0, 0, undefined, undefined, 0);
+    TestUtils.validateResults(analysisResults9, 48, 0, 0, undefined, undefined, 0);
 });
 
 test('Deprecated2', () => {

--- a/packages/pyright-internal/src/tests/samples/deprecated1.py
+++ b/packages/pyright-internal/src/tests/samples/deprecated1.py
@@ -26,7 +26,7 @@ from typing import (
     Reversible,
     Container,
     Collection as C1,
-    Callable,
+    Callable, # should not report an error because Callable is completely unrelated to collections
     AbstractSet,
     MutableSet,
     Mapping,


### PR DESCRIPTION
fixes #77