### PR TITLE
fix `reportDuplicateImport` not reporting duplicated aliases and duplicated imports across different `import` statements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Pyright current file",
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "npm: build:cli:dev",
+            "console": "integratedTerminal",
+            "program": "${workspaceFolder}/packages/pyright/index.js",
+            "args": ["${file}"]
+        },
+        {
             "name": "Pyright tests",
             "type": "node",
             "request": "launch",

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { ConfigOptions } from '../common/configOptions';
+import { DiagnosticRule } from '../common/diagnosticRules';
 import { PythonVersion } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
@@ -371,6 +372,18 @@ test('DuplicateImports1', () => {
     configOptions.diagnosticRuleSet.reportDuplicateImport = 'error';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['duplicateImports1.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2);
+});
+
+test('DuplicateImports2', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportDuplicateImport = 'error';
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['duplicateImports2.py'], configOptions);
+    TestUtils.validateResultsButBased(analysisResults, {
+        errors: [
+            { line: 1, code: DiagnosticRule.reportDuplicateImport },
+            { line: 5, code: DiagnosticRule.reportDuplicateImport },
+        ],
+    });
 });
 
 test('ParamNames1', () => {

--- a/packages/pyright-internal/src/tests/samples/duplicateImports2.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateImports2.py
@@ -1,0 +1,10 @@
+# should report error on imports with duplicated aliases
+import typing as foo, collections.abc as foo
+
+# should report error on duplicated imports in different statements
+from dataclasses import dataclass
+from dataclasses import dataclass
+
+# prevent unusedCodes
+_ = foo
+_ = dataclass


### PR DESCRIPTION
- fixes #89 
- fixes #88 