### PR TITLE
fix `reportDeclaration` not reporting multiple redeclarations of the same type

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3429,17 +3429,9 @@ export class Checker extends ParseTreeWalker {
                     }
                 }
             } else if (otherDecl.type === DeclarationType.Variable) {
-                const primaryType = this._evaluator.getTypeForDeclaration(primaryDecl)?.type;
-
                 if (otherDecl.typeAnnotationNode) {
                     if (otherDecl.node.nodeType === ParseNodeType.Name) {
                         let duplicateIsOk = false;
-
-                        // It's OK if they both have the same declared type.
-                        const otherType = this._evaluator.getTypeForDeclaration(otherDecl)?.type;
-                        if (primaryType && otherType && isTypeSame(primaryType, otherType)) {
-                            duplicateIsOk = true;
-                        }
 
                         if (primaryDecl.type === DeclarationType.TypeParameter) {
                             // The error will be reported elsewhere if a type parameter is

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -427,7 +427,7 @@ test('InconsistentSpaceTab2', () => {
 test('DuplicateDeclaration1', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['duplicateDeclaration1.py']);
 
-    TestUtils.validateResults(analysisResults, 10);
+    TestUtils.validateResults(analysisResults, 11);
 });
 
 test('DuplicateDeclaration2', () => {

--- a/packages/pyright-internal/src/tests/samples/annotatedVar2.py
+++ b/packages/pyright-internal/src/tests/samples/annotatedVar2.py
@@ -10,8 +10,9 @@ glob_var1 = Exception()  # type: str
 
 glob_var1 = Exception()  # type: Exception
 
-# This should generate an error because the assigned
-# type doesn't match the declared type.
+# This should generate two errors: one because the assigned
+# type doesn't match the declared type, and the other because
+# it's a redeclaration
 glob_var1 = "hello"  # type: Exception
 
 # This should generate an error.

--- a/packages/pyright-internal/src/tests/samples/annotatedVar4.py
+++ b/packages/pyright-internal/src/tests/samples/annotatedVar4.py
@@ -6,8 +6,9 @@ class ClassA(object):
     # type doesn't match the latter declared type.
     class_var1 = 4  # type: str
 
-    # This should generate an error because the assigned
-    # value doesn't match the declared type.
+    # This should generate two errors because the assigned
+    # value doesn't match the declared type, and because
+    # it's redeclared
     class_var1 = "hello"  # type: int
 
     class_var1 = 3  # type: int

--- a/packages/pyright-internal/src/tests/samples/annotatedVar5.py
+++ b/packages/pyright-internal/src/tests/samples/annotatedVar5.py
@@ -14,8 +14,9 @@ class ClassC(object):
         pass
 
     def foo(self):
-        # This should generate an error because the assigned
-        # type doesn't match the declared type.
+        # This should generate two errors because the assigned
+        # type doesn't match the declared type, and because it's
+        # redeclared below.
         self.inst_var1 = 3  # type: str
 
         self.inst_var1: str = "hello"

--- a/packages/pyright-internal/src/tests/samples/annotations4.py
+++ b/packages/pyright-internal/src/tests/samples/annotations4.py
@@ -48,6 +48,7 @@ def my_func(param1: int, param2):
 
 # This should be fine because both declarations of 'e'
 # use the same type.
+# edit: actually no its not thats cringe
 e: list[int]
 e = [3]
 e: list[int]

--- a/packages/pyright-internal/src/tests/samples/duplicateDeclaration1.py
+++ b/packages/pyright-internal/src/tests/samples/duplicateDeclaration1.py
@@ -13,6 +13,7 @@ class C:
     def f(self):
         return 0
 
+    # This should generate an error.
     def f(self):
         return 1
 

--- a/packages/pyright-internal/src/tests/samples/final3.py
+++ b/packages/pyright-internal/src/tests/samples/final3.py
@@ -41,6 +41,7 @@ class Foo:
 
     member2: typing.Final[int] = 3
 
+    # this should generate an error because it's a redeclaration
     member4: Final[int]
 
     # This should generate an error because there is

--- a/packages/pyright-internal/src/tests/samples/genericType3.py
+++ b/packages/pyright-internal/src/tests/samples/genericType3.py
@@ -24,4 +24,4 @@ root_int: Root[int] = Root[int](lambda x: x << 2)
 root_float: Root[float] = root_int
 
 # This should generate an error.
-root_float: Root[float] = Root[int](lambda x: x << 2)
+root_float2: Root[float] = Root[int](lambda x: x << 2)

--- a/packages/pyright-internal/src/tests/samples/recursiveTypeAlias1.py
+++ b/packages/pyright-internal/src/tests/samples/recursiveTypeAlias1.py
@@ -54,7 +54,7 @@ b5: RecursiveTuple = (1, ("1", 1), (1, (1, 2)))
 b6: RecursiveTuple = (1, ("1", 1), (1, (1, [2])))
 
 # This should generate an error
-b6: RecursiveTuple = (1, [1])
+b7: RecursiveTuple = (1, [1])
 
 
 RecursiveMapping = Union[str, int, Mapping[str, "RecursiveMapping"]]

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -927,7 +927,7 @@ test('Annotations3', () => {
 test('Annotations4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotations4.py']);
 
-    TestUtils.validateResults(analysisResults, 8);
+    TestUtils.validateResults(analysisResults, 9);
 });
 
 test('Annotations5', () => {
@@ -951,7 +951,7 @@ test('AnnotatedVar1', () => {
 test('AnnotatedVar2', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotatedVar2.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('AnnotatedVar3', () => {
@@ -963,13 +963,13 @@ test('AnnotatedVar3', () => {
 test('AnnotatedVar4', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotatedVar4.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('AnnotatedVar5', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['annotatedVar5.py']);
 
-    TestUtils.validateResults(analysisResults, 5);
+    TestUtils.validateResults(analysisResults, 6);
 });
 
 test('AnnotatedVar6', () => {

--- a/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator3.test.ts
@@ -562,7 +562,7 @@ test('TypeAlias4', () => {
 
     configOptions.defaultPythonVersion = PythonVersion.V3_9;
     const analysisResults3_9 = TestUtils.typeAnalyzeSampleFiles(['typeAlias4.py'], configOptions);
-    TestUtils.validateResults(analysisResults3_9, 1);
+    TestUtils.validateResults(analysisResults3_9, 2);
 
     configOptions.defaultPythonVersion = PythonVersion.V3_10;
     const analysisResults3_10 = TestUtils.typeAnalyzeSampleFiles(['typeAlias4.py'], configOptions);

--- a/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator4.test.ts
@@ -14,6 +14,7 @@ import { ConfigOptions } from '../common/configOptions';
 import { PythonVersion } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import * as TestUtils from './testUtils';
+import { DiagnosticRule } from '../common/diagnosticRules';
 
 test('Required1', () => {
     // Analyze with Python 3.10 settings.
@@ -367,7 +368,7 @@ test('Final2', () => {
 
 test('Final3', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['final3.py']);
-    TestUtils.validateResults(analysisResults, 30);
+    TestUtils.validateResults(analysisResults, 31);
 });
 
 test('Final4', () => {
@@ -659,7 +660,9 @@ test('DataClass13', () => {
 test('DataClass14', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['dataclass14.py']);
 
-    TestUtils.validateResults(analysisResults, 0);
+    TestUtils.validateResultsButBased(analysisResults, {
+        errors: [{ line: 9, code: DiagnosticRule.reportRedeclaration }],
+    });
 });
 
 test('DataClass15', () => {


### PR DESCRIPTION
receclarations of the same time are always a mistake, even more so than redeclarations of different types (which you may sometimes want to do)

fixes #70