### PR TITLE
Neovim setup (updated)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,10 +8,10 @@
 see https://github.com/DetachHead/basedpyright#vscode-extension
 
 #### Neovim
-BasedPyright is not yet available to the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) repo, which declares all the supported severs and their configurations.  But it can be configured through the [`pyright`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#pyright) explicitly declaring the command name in the settings:
+BasedPyright is available through the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#basedpyright) adapter for native Neovim's LSP support.  To configure it simply add this to your Neovim's settings:
 ```lua
 local lspconfig = require("lspconfig")
-lspconfig.pyright.setup { cmd = { "basedpyright-langserver", "--stdio" } }
+lspconfig.basedpyright.setup {}
 ```
 
 #### Vim

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,11 +8,12 @@
 see https://github.com/DetachHead/basedpyright#vscode-extension
 
 #### Neovim
-BasedPyright is available through the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#basedpyright) adapter for native Neovim's LSP support.  To configure it simply add this to your Neovim's settings:
+BasedPyright is available through the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#basedpyright) adapter for native Neovim's LSP support.  TL;DR simply add this to your Neovim's settings:
 ```lua
 local lspconfig = require("lspconfig")
-lspconfig.basedpyright.setup {}
+lspconfig.basedpyright.setup{}
 ```
+Further info for this LSP server options for `nvim-lspconfig` are available on their docs, linked above.
 
 #### Vim
 Vim/Neovim users can install [coc-pyright](https://github.com/fannheyward/coc-pyright), the Pyright extension for coc.nvim.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,8 +7,15 @@
 #### VS Code
 see https://github.com/DetachHead/basedpyright#vscode-extension
 
+#### Neovim
+BasedPyright is not yet available to the [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md) repo, which declares all the supported severs and their configurations.  But it can be configured through the [`pyright`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#pyright) explicitly declaring the command name in the settings:
+```lua
+local lspconfig = require("lspconfig")
+lspconfig.pyright.setup { cmd = { "basedpyright-langserver", "--stdio" } }
+```
+
 #### Vim
-Vim/neovim users can install [coc-pyright](https://github.com/fannheyward/coc-pyright), the Pyright extension for coc.nvim.
+Vim/Neovim users can install [coc-pyright](https://github.com/fannheyward/coc-pyright), the Pyright extension for coc.nvim.
 
 Alternatively, [ALE](https://github.com/dense-analysis/ale) will automatically check your code with Pyright if added to the linters list.
 


### PR DESCRIPTION
As result of [this PR](https://github.com/neovim/nvim-lspconfig/pull/3078) being accepted and merged; now Neovim configuration is more direct.

There is no need to continue using another LSP server's configuration to be loaded into Neovim via `nvim-lspconfig`.