### PR TITLE
report non-top level duplicate imports

### DIFF
--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -1931,7 +1931,14 @@ export class Binder extends ParseTreeWalker {
                 const nameNode = importSymbolNode.alias || importSymbolNode.name;
 
                 AnalyzerNodeInfo.setFlowNode(importSymbolNode, this._currentFlowNode!);
-
+                if (this._currentScope.lookUpSymbolRecursive(nameNode.value)) {
+                    this._addDiagnostic(
+                        this._fileInfo.diagnosticRuleSet.reportDuplicateImport,
+                        DiagnosticRule.reportDuplicateImport,
+                        LocMessage.duplicateImport().format({ importName: nameNode.value }),
+                        node
+                    );
+                }
                 const symbol = this._bindNameToScope(this._currentScope, nameNode);
 
                 if (symbol) {


### PR DESCRIPTION
fixes #117 

need to figure out how to do this on module name imports, eg:
```py
import collections.abc

if bool():
    import collections.abc # should be an error
    import collections # should this be an error?
```