### PR TITLE
option to enforce error codes in `type:ignore`/`pyright:ignore` comments

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
         "tamasfe.even-better-toml",
         "redhat.vscode-yaml",
         "github.vscode-github-actions",
-        "gabdug.pdm"
+        "gabdug.pdm",
+        "Orta.vscode-jest"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ used to be `basic`, but now defaults to `all`. in the future we intend to add [b
 #### `pythonPlatform`
 used to assume that the operating system pyright is being run on is the only operating system your code will run on, which is rarely the case. in basedpyright, `pythonPlatform` defaults to `All`, which assumes your code can run on any operating system.
 
+### added error codes for all errors and option to enforce error codes in `type:ignore` comments
+
+it's always best to specify an error code in your `type:ignore` comments:
+
+```py
+# type:ignore[reportUnreachable]
+```
+
+that way, if the error changes or a new error appears on the same line in the future, you'll get a new error because the comment doesn't account for the other error. unfortunately there are many rules in pyright that do not have error codes, so you can't always do this.
+
+basedpyright resolves this by reporting those errors under the `reportGeneralTypeIssues` code. this isn't a perfect solution, but there are over 100 code-less errors that would otherwise need their own rules. i intend to split them into their own rules in the future, but this will do for now.
+
+this also allows for the new `reportIgnoreCommentWithoutRule` rule.
+
 ## basedmypy feature parity
 
 [basedmypy](https://github.com/kotlinisland/basedmypy) is a fork of mypy with a similar goal in mind: to fix some of the serious problems in mypy that do not seem to be a priority for the maintainers. it also adds many new features which may not be standardized but greatly improve the developer experience when working with python's far-from-perfect type system.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,8 @@ the following additional options are not available in regular pyright:
 
 <a name="reportAny"></a> **reportAny** [boolean or string, optional]: Ban all usages of the `Any` type. this accounts for all scenarios not covered by the `reportUnknown*` rules (since "Unknown" isn't a real type, but a distinction pyright makes to disallow the `Any` type only in certain circumstances).
 
+<a name="reportIgnoreCommentWithoutRule"></a> **reportIgnoreCommentWithoutRule** [boolean or string, optional]: Enforce that all `# type:ignore`/`# pyright:ignore` comments specify a rule in brackets (eg. `# pyright:ignore[reportAny]`)
+
 ## Execution Environment Options
 Pyright allows multiple “execution environments” to be defined for different portions of your source tree. For example, a subtree may be designed to run with different import search paths or a different version of the python interpreter than the rest of the source base.
 
@@ -434,6 +436,7 @@ The following table lists the default severity levels for each diagnostic rule w
 | reportUnusedCallResult                    | "none"     | "none"     | "none"     | "none"     | "error"    |
 | reportUnreachable                         | "none"     | "none"     | "none"     | "none"     | "error"    |
 | reportAny                                 | "none"     | "none"     | "none"     | "none"     | "error"    |
+| reportIgnoreCommentWithoutRule            | "none"     | "none"     | "none"     | "none"     | "error"    |
 
 
 ## Locale Configuration

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -995,11 +995,13 @@ export class SourceFile {
         }
 
         // report diagnostics for ignore comments that don't specify rules
-        if (this._diagnosticRuleSet.reportIgnoreCommentWithoutRule) {
+        const ignoreCommentWithoutRule = this._diagnosticRuleSet.reportIgnoreCommentWithoutRule;
+        if (ignoreCommentWithoutRule !== 'none') {
+            const category = convertLevelToCategory(this._diagnosticRuleSet.reportIgnoreCommentWithoutRule);
             for (const ignoreComment of this._writableData.pyrightIgnoreLines.values()) {
                 if (!ignoreComment.rulesList.length) {
                     const diagnostic = new Diagnostic(
-                        DiagnosticCategory.Error,
+                        category,
                         LocMessage.pyrightIgnoreCommentWithoutRule(),
                         this._getRangeFromIgnoreComment(ignoreComment)
                     );
@@ -1011,7 +1013,7 @@ export class SourceFile {
                 for (const ignoreComment of this._writableData.typeIgnoreLines.values()) {
                     if (!ignoreComment.rulesList.length) {
                         const diagnostic = new Diagnostic(
-                            DiagnosticCategory.Error,
+                            category,
                             LocMessage.typeIgnoreCommentWithoutRule(),
                             this._getRangeFromIgnoreComment(ignoreComment)
                         );

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -3228,7 +3228,10 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
         return addDiagnosticWithSuppressionCheck('information', message, node, range);
     }
 
+    /** @deprecated use {@link addDiagnostic} with a specific diagnostic rule instead */
     function addError(message: string, node: ParseNode, range?: TextRange) {
+        //TODO: the errors about ignore comments do not call this function and therefore do not
+        // have a code. but suppressing an unused ignore comment is an edge case sooooo
         return addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, message, node, range);
     }
 

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -3229,7 +3229,7 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
     }
 
     function addError(message: string, node: ParseNode, range?: TextRange) {
-        return addDiagnosticWithSuppressionCheck('error', message, node, range);
+        return addDiagnostic(DiagnosticRule.reportGeneralTypeIssues, message, node, range);
     }
 
     function addUnusedCode(node: ParseNode, textRange: TextRange) {

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -387,6 +387,9 @@ export interface DiagnosticRuleSet {
 
     // Report usages of Any-typed values
     reportAny: DiagnosticLevel;
+
+    // Report ignore comments without a specified rule
+    reportIgnoreCommentWithoutRule: DiagnosticLevel;
 }
 
 export function cloneDiagnosticRuleSet(diagSettings: DiagnosticRuleSet): DiagnosticRuleSet {
@@ -505,6 +508,7 @@ export function getDiagLevelDiagnosticRules() {
         DiagnosticRule.reportImplicitOverride,
         DiagnosticRule.reportUnreachable,
         DiagnosticRule.reportAny,
+        DiagnosticRule.reportIgnoreCommentWithoutRule,
     ];
 }
 
@@ -613,6 +617,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportImplicitOverride: 'none',
         reportUnreachable: 'none',
         reportAny: 'none',
+        reportIgnoreCommentWithoutRule: 'none',
     };
 
     return diagSettings;
@@ -717,6 +722,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportImplicitOverride: 'none',
         reportUnreachable: 'none',
         reportAny: 'none',
+        reportIgnoreCommentWithoutRule: 'none',
     };
 
     return diagSettings;
@@ -821,6 +827,7 @@ export function getStandardDiagnosticRuleSet(): DiagnosticRuleSet {
         reportImplicitOverride: 'none',
         reportUnreachable: 'none',
         reportAny: 'none',
+        reportIgnoreCommentWithoutRule: 'none',
     };
 
     return diagSettings;
@@ -924,6 +931,7 @@ export const getAllDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportImplicitOverride: 'error',
     reportUnreachable: 'error',
     reportAny: 'error',
+    reportIgnoreCommentWithoutRule: 'error',
 });
 
 export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
@@ -1025,6 +1033,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportImplicitOverride: 'none',
         reportUnreachable: 'none',
         reportAny: 'none',
+        reportIgnoreCommentWithoutRule: 'none',
     };
 
     return diagSettings;

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -106,4 +106,5 @@ export enum DiagnosticRule {
     // basedpyright options:
     reportUnreachable = 'reportUnreachable',
     reportAny = 'reportAny',
+    reportIgnoreCommentWithoutRule = 'reportIgnoreCommentWithoutRule',
 }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -1170,6 +1170,8 @@ export namespace Localizer {
         export const yieldWithinListCompr = () => getRawString('Diagnostic.yieldWithinListCompr');
         export const zeroCaseStatementsFound = () => getRawString('Diagnostic.zeroCaseStatementsFound');
         export const zeroLengthTupleNotAllowed = () => getRawString('Diagnostic.zeroLengthTupleNotAllowed');
+        export const pyrightIgnoreCommentWithoutRule = () => getRawString('Diagnostic.pyrightIgnoreCommentWithoutRule');
+        export const typeIgnoreCommentWithoutRule = () => getRawString('Diagnostic.typeIgnoreCommentWithoutRule');
     }
 
     export namespace DiagnosticAddendum {

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -616,7 +616,9 @@
         "yieldOutsideFunction": "\"yield\" not allowed outside of a function or lambda",
         "yieldWithinListCompr": "\"yield\" not allowed inside a list comprehension",
         "zeroCaseStatementsFound": "Match statement must include at least one case statement",
-        "zeroLengthTupleNotAllowed": "Zero-length tuple is not allowed in this context"
+        "zeroLengthTupleNotAllowed": "Zero-length tuple is not allowed in this context",
+        "pyrightIgnoreCommentWithoutRule": "`pyright: ignore` comment must specify a rule (eg. `# pyright: ignore[ruleName]`)",
+        "typeIgnoreCommentWithoutRule": "`type: ignore` comment must specify a rule (eg. `# type: ignore[ruleName]`)"
     },
     "DiagnosticAddendum": {
         "annotatedNotAllowed": "\"Annotated\" special form cannot be used with instance and class checks",

--- a/packages/pyright-internal/src/parser/tokenizer.ts
+++ b/packages/pyright-internal/src/parser/tokenizer.ts
@@ -193,7 +193,7 @@ export interface IgnoreCommentRule {
 
 export interface IgnoreComment {
     range: TextRange;
-    rulesList: IgnoreCommentRule[] | undefined;
+    rulesList: IgnoreCommentRule[];
 }
 
 interface FStringReplacementFieldContext {
@@ -1305,9 +1305,9 @@ export class Tokenizer {
     }
 
     // Extracts the individual rules within a "type: ignore [x, y, z]" comment.
-    private _getIgnoreCommentRulesList(start: number, match: RegExpMatchArray): IgnoreCommentRule[] | undefined {
+    private _getIgnoreCommentRulesList(start: number, match: RegExpMatchArray): IgnoreCommentRule[] {
         if (match.length < 5 || match[4] === undefined) {
-            return undefined;
+            return [];
         }
 
         const splitElements = match[4].split(',');

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -13,6 +13,7 @@ import { ConfigOptions } from '../common/configOptions';
 import { DiagnosticRule } from '../common/diagnosticRules';
 import { pythonVersion3_10, pythonVersion3_8, pythonVersion3_9 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
+import { LocMessage } from '../localization/localize';
 import * as TestUtils from './testUtils';
 
 test('BadToken1', () => {
@@ -352,6 +353,50 @@ test('PyrightIgnore2', () => {
     configOptions.diagnosticRuleSet.reportUnnecessaryTypeIgnoreComment = 'warning';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['pyrightIgnore2.py'], configOptions);
     TestUtils.validateResults(analysisResults, 2, 3);
+});
+
+test('pyrightIgnoreCommentsBased', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.diagnosticRuleSet.reportIgnoreCommentWithoutRule = 'error';
+    configOptions.diagnosticRuleSet.enableTypeIgnoreComments = false;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['pyrightIgnoreBased.py'], configOptions);
+    TestUtils.validateResultsButBased(analysisResults, {
+        errors: [
+            {
+                line: 0,
+                message: LocMessage.pyrightIgnoreCommentWithoutRule(),
+                code: DiagnosticRule.reportIgnoreCommentWithoutRule,
+            },
+            {
+                line: 1,
+                message: LocMessage.pyrightIgnoreCommentWithoutRule(),
+                code: DiagnosticRule.reportIgnoreCommentWithoutRule,
+            },
+        ],
+    });
+});
+
+test('typeIgnoreCommentsBased', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+
+    configOptions.diagnosticRuleSet.reportIgnoreCommentWithoutRule = 'error';
+    configOptions.diagnosticRuleSet.enableTypeIgnoreComments = true;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeIgnoreBased.py'], configOptions);
+    TestUtils.validateResultsButBased(analysisResults, {
+        errors: [
+            {
+                line: 0,
+                message: LocMessage.typeIgnoreCommentWithoutRule(),
+                code: DiagnosticRule.reportIgnoreCommentWithoutRule,
+            },
+            {
+                line: 1,
+                message: LocMessage.typeIgnoreCommentWithoutRule(),
+                code: DiagnosticRule.reportIgnoreCommentWithoutRule,
+            },
+        ],
+    });
 });
 
 test('PyrightComment1', () => {

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -348,11 +348,11 @@ test('PyrightIgnore2', () => {
     const configOptions = new ConfigOptions(Uri.empty());
 
     let analysisResults = TestUtils.typeAnalyzeSampleFiles(['pyrightIgnore2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 2);
+    TestUtils.validateResults(analysisResults, 1);
 
     configOptions.diagnosticRuleSet.reportUnnecessaryTypeIgnoreComment = 'warning';
     analysisResults = TestUtils.typeAnalyzeSampleFiles(['pyrightIgnore2.py'], configOptions);
-    TestUtils.validateResults(analysisResults, 2, 3);
+    TestUtils.validateResults(analysisResults, 1, 3);
 });
 
 test('pyrightIgnoreCommentsBased', () => {

--- a/packages/pyright-internal/src/tests/samples/pyrightIgnore2.py
+++ b/packages/pyright-internal/src/tests/samples/pyrightIgnore2.py
@@ -14,6 +14,7 @@ def func1(self, x: int | None) -> str:
     v3 = x + x  # pyright: ignore [foo, bar]
 
     # This will not suppress the error
+    # erm actually it does because it's now treated the same as an ignore comment with no codes soooo
     v4 = x + x  # pyright: ignore []
 
     # One of these is unnecessary

--- a/packages/pyright-internal/src/tests/samples/pyrightIgnoreBased.py
+++ b/packages/pyright-internal/src/tests/samples/pyrightIgnoreBased.py
@@ -1,0 +1,6 @@
+asdf # pyright:ignore
+asdf # pyright:ignore[]
+
+# no errors because type ignore comments are disabled
+# type:ignore
+# type:ignore[]

--- a/packages/pyright-internal/src/tests/samples/typeIgnoreBased.py
+++ b/packages/pyright-internal/src/tests/samples/typeIgnoreBased.py
@@ -1,0 +1,2 @@
+asdf # type:ignore
+asdf # type:ignore[]

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1518,6 +1518,22 @@
                                 true,
                                 false
                             ]
+                        },
+                        "reportIgnoreCommentWithoutRule": {
+                            "type": [
+                                "string",
+                                "boolean"
+                            ],
+                            "description": "Diagnostics for `# type: ignore` and `# pyright: ignore` comments without specifying a rule",
+                            "default": "none",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error",
+                                true,
+                                false
+                            ]
                         }
                     }
                 },

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -666,6 +666,12 @@
       "title": "Controls reporting of values typed as `Any`",
       "default": "none"
     },
+    "reportIgnoreCommentWithoutRule": {
+      "$id": "#/properties/reportIgnoreCommentWithoutRule",
+      "$ref": "#/definitions/diagnostic",
+      "title": "Controls reporting `# type: ignore` and `# pyright: ignore` comments without specifying a rule",
+      "default": "none"
+    },
     "extraPaths": {
       "$id": "#/properties/extraPaths",
       "type": "array",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ respect-gitignore = true
 line-length = 100
 preview = true
 unsafe-fixes = true
-extend-exclude = ["pw", "packages/pyright-internal/typeshed-fallback", "packages/pyright-internal/src/tests/samples"]
+extend-exclude = ["pw", "packages/pyright-internal/typeshed-fallback", "packages/pyright-internal/src/tests/samples", "build/generateUnicodeTables.py"]
 
 [tool.ruff.lint]
 extend-select = ["ALL"]


### PR DESCRIPTION
- fixes #23 
- fixes #4