### PR TITLE
Fix the stubs for `Any`

### DIFF
--- a/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
+++ b/packages/pyright-internal/typeshed-fallback/stdlib/typing.pyi
@@ -131,7 +131,11 @@ if sys.version_info >= (3, 12):
 if sys.version_info >= (3, 13):
     __all__ += ["get_protocol_members", "is_protocol", "NoDefault"]
 
-Any = object()
+if sys.version_info < (3, 11):
+    Any: _SpecialForm
+else:
+    class _AnyMeta(type): ...
+    class Any(metaclass=_AnyMeta): ...
 
 def final(f: _T) -> _T: ...
 @final


### PR DESCRIPTION
This is currently causing anything that is `Any` to be seen as `Unknown`
Or that it's a real class and nothing is compatible with it.