### PR TITLE
add error when attempting to subscript `AbstractContextManager` and `AbstractAsyncContextManager` at runtime on python 3.8

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+      - run: ./pw pdm use ${{ env.PYTHON_VERSION }}
 
       - run: ./pw pdm install
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+      - run: ./pw pdm use ${{ env.PYTHON_VERSION }}
 
       # need to use pw script at least once even when activating the context so that the wrapper installs pyprojectx
       - run: ./pw pdm lock --check

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -6504,7 +6504,11 @@ export function createTypeEvaluator(importLookup: ImportLookup, evaluatorOptions
                 const fileInfo = AnalyzerNodeInfo.getFileInfo(node);
                 if (
                     isInstantiableClass(baseTypeResult.type) &&
-                    ClassType.isBuiltIn(baseTypeResult.type) &&
+                    // TODO: figure out what's going on here. this returns false for AbstractContextManager, idk why.
+                    //  i think it's because its base class is Protocol in the stubs but it's actually an abc at runtime.
+                    //  that also raises the question of why the isInstantiableClass call above returns true, when
+                    //  protocols are not instantiable.
+                    // ClassType.isBuiltIn(baseTypeResult.type) &&
                     !baseTypeResult.type.aliasName
                 ) {
                     const minPythonVersion = nonSubscriptableBuiltinTypes.get(baseTypeResult.type.details.fullName);

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -425,6 +425,7 @@ const nonSubscriptableBuiltinTypes: Map<string, PythonVersion> = new Map([
     ['collections.DefaultDict', pythonVersion3_9],
     ['collections.deque', pythonVersion3_9],
     ['collections.OrderedDict', pythonVersion3_9],
+    ['contextlib.AbstractContextManager', pythonVersion3_9],
     ['queue.Queue', pythonVersion3_9],
 ]);
 

--- a/packages/pyright-internal/src/tests/samples/subscript_check.py
+++ b/packages/pyright-internal/src/tests/samples/subscript_check.py
@@ -1,0 +1,10 @@
+from contextlib import AbstractContextManager
+from typing import ContextManager
+
+ContextManagerAlias = ContextManager
+AbstractContextManagerAlias = AbstractContextManager
+
+foo: ContextManagerAlias[None]
+bar: AbstractContextManagerAlias[None] # error
+baz: ContextManager[None]
+qux: AbstractContextManager[None] # error

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -1,5 +1,6 @@
 import { BasedConfigOptions, ConfigOptions } from '../common/configOptions';
 import { DiagnosticRule } from '../common/diagnosticRules';
+import { pythonVersion3_8 } from '../common/pythonVersion';
 import { Uri } from '../common/uri/uri';
 import { UriEx } from '../common/uri/uriUtils';
 import { resolveSampleFilePath, typeAnalyzeSampleFiles, validateResultsButBased } from './testUtils';
@@ -72,6 +73,20 @@ test('reportInvalidCast', () => {
         errors: [
             { code: DiagnosticRule.reportInvalidCast, line: 4 },
             { code: DiagnosticRule.reportInvalidCast, line: 5 },
+        ],
+    });
+});
+
+test('subscript context manager types on 3.8', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.defaultPythonVersion = pythonVersion3_8;
+    const analysisResults = typeAnalyzeSampleFiles(['subscript_check.py'], configOptions);
+    const message =
+        'Subscript for class "AbstractContextManager" will generate runtime exception; enclose type annotation in quotes';
+    validateResultsButBased(analysisResults, {
+        errors: [
+            { code: DiagnosticRule.reportGeneralTypeIssues, line: 7, message },
+            { code: DiagnosticRule.reportGeneralTypeIssues, line: 9, message },
         ],
     });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pyprojectx]
-main = ["pdm==2.12.4"]
+main = ["pdm==2.13.2"]
 
 [tool.pdm]
 distribution = true


### PR DESCRIPTION
fixes #24 