### PR TITLE
activate vscode extension if workspace contains a `pyproject.toml`

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -24,7 +24,8 @@
     ],
     "activationEvents": [
         "onLanguage:python",
-        "workspaceContains:pyrightconfig.json"
+        "workspaceContains:pyrightconfig.json",
+        "workspaceContains:pyproject.toml"
     ],
     "icon": "images/pyright-icon.png",
     "main": "./dist/extension.js",


### PR DESCRIPTION
fixes #124