### PR TITLE
Run as a Python module

### DIFF
--- a/basedpyright/__main__.py
+++ b/basedpyright/__main__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from basedpyright.run_node import run
+
+
+def main():
+    run("index")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Thank you for this awesome fork!

I suggest to allow running `basedpyright` as a Python module: `python -m basedpyright`. My motivation is that other popular tools, like `flake8`, `mypy`, and even `basedmypy` support this.

Please let me know what you think.