### PR TITLE
fix normal variables incorrectly getting a `TypeAlias` inlay hint if their type came from a type alias

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
@@ -1,16 +1,7 @@
 import { Range } from 'vscode-languageserver-types';
 import { ParseTreeWalker } from '../analyzer/parseTreeWalker';
 import { isDunderName, isUnderscoreOnlyName } from '../analyzer/symbolNameUtils';
-import {
-    FunctionType,
-    Type,
-    TypeFlags,
-    getTypeAliasInfo,
-    isAny,
-    isClass,
-    isParamSpec,
-    isTypeVar,
-} from '../analyzer/types';
+import { FunctionType, Type, getTypeAliasInfo, isAny, isClass, isParamSpec, isTypeVar } from '../analyzer/types';
 import { ProgramView } from '../common/extensibility';
 import { limitOverloadBasedOnCall } from '../languageService/tooltipUtils';
 import {
@@ -123,7 +114,10 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
                     inlayHintType: 'variable',
                     position: node.start + node.length,
                     value: `: ${
-                        getTypeAliasInfo(type) && type.flags & TypeFlags.Instantiable
+                        type.typeAliasInfo &&
+                        node.nodeType === ParseNodeType.Name &&
+                        // prevent variables whose type comes from a type alias from being incorrectly treated as a TypeAlias.
+                        getTypeAliasInfo(type)?.name === node.value
                             ? 'TypeAlias'
                             : this._printType(type)
                     }`,

--- a/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
@@ -1,7 +1,16 @@
 import { Range } from 'vscode-languageserver-types';
 import { ParseTreeWalker } from '../analyzer/parseTreeWalker';
 import { isDunderName, isUnderscoreOnlyName } from '../analyzer/symbolNameUtils';
-import { FunctionType, Type, getTypeAliasInfo, isAny, isClass, isParamSpec, isTypeVar } from '../analyzer/types';
+import {
+    FunctionType,
+    Type,
+    TypeFlags,
+    getTypeAliasInfo,
+    isAny,
+    isClass,
+    isParamSpec,
+    isTypeVar,
+} from '../analyzer/types';
 import { ProgramView } from '../common/extensibility';
 import { limitOverloadBasedOnCall } from '../languageService/tooltipUtils';
 import {
@@ -113,7 +122,11 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
                 this.featureItems.push({
                     inlayHintType: 'variable',
                     position: node.start + node.length,
-                    value: `: ${getTypeAliasInfo(type) ? 'TypeAlias' : this._printType(type)}`,
+                    value: `: ${
+                        getTypeAliasInfo(type) && type.flags & TypeFlags.Instantiable
+                            ? 'TypeAlias'
+                            : this._printType(type)
+                    }`,
                 });
             }
         }

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/variables.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/variables.py
@@ -3,8 +3,11 @@ from typing_extensions import TypeVar, ParamSpec
 sss = str(1)  # inlay hint
 foo = 1  # no inlay hint because Literal
 T = TypeVar(name="T") # no inlay hint because typevar
-U = TypeVar(name="U", bound=Function) # no inlay hint because typevar
+U = TypeVar(name="U", bound=int) # no inlay hint because typevar
 P = ParamSpec(name="P") # no inlay hint because paramspec
 _ = str(1)  # no inlay hint because underscore only variable
 Foo = int  # inlay hint of "TypeAlias"
 type Bar = str  # no inlay hint
+def asdf(a: Foo, b: type[Foo]) -> None:
+    foo = a # inlay hint, it's an instance not a type
+    bar = b # inlay hint of "TypeAlias", parameters that where the values are types are valid as type annotations

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/variables.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/variables.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from typing_extensions import TypeVar, ParamSpec
 
 sss = str(1)  # inlay hint
@@ -8,6 +9,9 @@ P = ParamSpec(name="P") # no inlay hint because paramspec
 _ = str(1)  # no inlay hint because underscore only variable
 Foo = int  # inlay hint of "TypeAlias"
 type Bar = str  # no inlay hint
-def asdf(a: Foo, b: type[Foo]) -> None:
-    foo = a # inlay hint, it's an instance not a type
-    bar = b # inlay hint of "TypeAlias", parameters that where the values are types are valid as type annotations
+def asdf(a: Foo, b: type[Foo], c: int | str, d: Literal[1, 2], e: type[int]) -> None:
+    foo = a # inlay hint
+    bar = b # inlay hint (type, but not TypeAlias)
+    baz = c # inlay hint
+    qux = d # inlay hint
+    quxx = e # inlay hint (type, but not TypeAlias)

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -7,23 +7,38 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             {
                 inlayHintType: 'variable',
-                position: 53,
+                position: 80,
                 value: ': str',
             },
             {
                 inlayHintType: 'variable',
-                position: 359,
+                position: 386,
                 value: ': TypeAlias',
             },
             {
                 inlayHintType: 'variable',
-                position: 474,
+                position: 547,
                 value: ': Foo',
             },
             {
                 inlayHintType: 'variable',
-                position: 528,
-                value: ': TypeAlias',
+                position: 572,
+                value: ': Foo', //should be `type[Foo]`. see https://github.com/microsoft/pyright/issues/7806
+            },
+            {
+                inlayHintType: 'variable',
+                position: 623,
+                value: ': int | str',
+            },
+            {
+                inlayHintType: 'variable',
+                position: 648,
+                value: ': Literal[1, 2]',
+            },
+            {
+                inlayHintType: 'variable',
+                position: 674,
+                value: ': type[int]',
             },
         ]);
     });
@@ -56,7 +71,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             {
                 inlayHintType: 'variable',
-                position: 53,
+                position: 80,
                 value: ': str',
             },
         ]);

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -12,7 +12,17 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             },
             {
                 inlayHintType: 'variable',
-                position: 364,
+                position: 359,
+                value: ': TypeAlias',
+            },
+            {
+                inlayHintType: 'variable',
+                position: 474,
+                value: ': Foo',
+            },
+            {
+                inlayHintType: 'variable',
+                position: 528,
                 value: ': TypeAlias',
             },
         ]);


### PR DESCRIPTION
fixes #183