### PR TITLE
fix `reportUnsafeMultipleInheritance` false positives when the class has a base class that does not define an `__init__` or `__init_subclass__`

### DIFF
--- a/packages/pyright-internal/src/tests/samples/missingSuperBased.py
+++ b/packages/pyright-internal/src/tests/samples/missingSuperBased.py
@@ -1,0 +1,88 @@
+# This sample tests the reportMissingSuperCall diagnostic check.
+
+from typing import final
+
+
+class ParentA:
+    pass
+
+
+class ParentB:
+    # This should generate an error because it's missing a super().__init__ call.
+    def __init__(self):
+        pass
+
+
+class ParentBPrime(ParentB):
+    pass
+
+
+class ParentC:
+    pass
+
+
+@final
+class ParentD:
+    def __init__(self):
+        pass
+
+    def __init_subclass__(cls) -> None:
+        pass
+
+
+class ChildA(ParentA, ParentB):
+    # This should generate an error.
+    def __init__(self):
+        pass
+
+    # This should generate an error.... NOT!!!!
+    def __init_subclass__(cls) -> None:
+        pass
+
+
+class ChildB(ParentA, ParentB):
+    def __init__(self):
+        super().__init__()
+
+
+class ChildC1(ParentA, ParentB):
+    def __init__(self):
+        ParentB.__init__(self)
+
+
+class ChildC2(ParentA, ParentB):
+    def __init__(self):
+        ParentA.__init__(self)
+        ParentB.__init__(self)
+
+
+class ChildCPrime(ParentA, ParentBPrime, ParentC):
+    def __init__(self):
+        super(ParentBPrime).__init__()
+
+
+class ChildD(ParentC):
+    # This should generate an error.... said no one ever
+    def __init__(self):
+        pass
+
+
+@final
+class ChildE(ParentC):
+    def __init__(self):
+        pass
+
+class Foo:
+    def __init_subclass__(cls) -> None:
+        pass
+
+class Bar(Foo):
+    def __init_subclass__(cls) -> None: # error
+        pass
+
+class Baz:
+    pass
+
+class Qux(Baz):
+    def __init_subclass__(cls) -> None: # no error
+        pass

--- a/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator2.test.ts
@@ -257,17 +257,16 @@ test('MissingSuper with reportUnsafeMultipleInheritance enabled', () => {
 
     configOptions.diagnosticRuleSet.reportMissingSuperCall = 'error';
     configOptions.diagnosticRuleSet.reportUnsafeMultipleInheritance = 'error';
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['missingSuper1.py'], configOptions);
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['missingSuperBased.py'], configOptions);
     TestUtils.validateResultsButBased(analysisResults, {
         errors: [
             { code: DiagnosticRule.reportMissingSuperCall, line: 34 },
-            { code: DiagnosticRule.reportMissingSuperCall, line: 38 },
             { code: DiagnosticRule.reportUnsafeMultipleInheritance, line: 32 },
             { code: DiagnosticRule.reportUnsafeMultipleInheritance, line: 42 },
             { code: DiagnosticRule.reportUnsafeMultipleInheritance, line: 47 },
             { code: DiagnosticRule.reportUnsafeMultipleInheritance, line: 52 },
             { code: DiagnosticRule.reportUnsafeMultipleInheritance, line: 58 },
-            { code: DiagnosticRule.reportMissingSuperCall, line: 65 },
+            { code: DiagnosticRule.reportMissingSuperCall, line: 79 },
         ],
     });
 });


### PR DESCRIPTION
fixes #350 