### PR TITLE
fix `Never` type aliases being coloured as a variable when using the new python 3.12 type alias syntax

### DIFF
--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/never.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/never.py
@@ -21,3 +21,6 @@ def inferred():
     value2: str = ''
     if not isinstance(value2, str):
         value2
+
+type Baz = Never
+baz: Baz

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -86,6 +86,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 293, length: 6 }, // value2
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 }, // str
             { type: 'variable', modifiers: [], start: 315, length: 6 }, // value2
+            { type: 'keyword', modifiers: [], start: 323, length: 4 }, // type
+            { type: 'type', modifiers: [], start: 328, length: 3 }, // Baz
+            { type: 'type', modifiers: [], start: 334, length: 5 }, // Never
+            { type: 'variable', modifiers: [], start: 340, length: 3 }, // baz
+            { type: 'type', modifiers: [], start: 345, length: 3 }, // Baz
         ]);
     });
 


### PR DESCRIPTION
fixes #402 