### PR TITLE
generate docstubs for all stdlib modules since some modules are partially compiled and there's no other reliable way to account for that

### DIFF
--- a/based_build/generate_docstubs.py
+++ b/based_build/generate_docstubs.py
@@ -17,7 +17,7 @@ def main():
     stubs_with_docs_path = Path("docstubs")
     if not stubs_with_docs_path.exists():
         copytree(stubs_path, stubs_with_docs_path, dirs_exist_ok=True)
-    docify(str(stubs_with_docs_path / "stdlib"), "--builtins-only", "--in-place")
+    docify(str(stubs_with_docs_path / "stdlib"), "--in-place")
 
 
 if __name__ == "__main__":

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -82,7 +82,7 @@ describe(`Basic language server tests`, () => {
     test('Initialize without workspace folder support', async () => {
         const code = `
 // @filename: test.py
-//// import [|/*marker*/os|]
+//// import [|/*marker*/_typeshed|]
         `;
         const info = await runLanguageServer(DEFAULT_WORKSPACE_ROOT, code, /* callInitialize */ false);
 
@@ -103,12 +103,12 @@ describe(`Basic language server tests`, () => {
         const hoverResult = await hover(info, 'marker');
         assert(hoverResult);
         assert(MarkupContent.is(hoverResult.contents));
-        assert.strictEqual(hoverResult.contents.value, '```python\n(module) os\n```');
+        assert.strictEqual(hoverResult.contents.value, '```python\n(module) _typeshed\n```');
     });
     test('Hover', async () => {
         const code = `
 // @filename: test.py
-//// import [|/*marker*/os|]
+//// import [|/*marker*/_typeshed|]
         `;
         const info = await runLanguageServer(DEFAULT_WORKSPACE_ROOT, code, /* callInitialize */ true);
 
@@ -117,7 +117,7 @@ describe(`Basic language server tests`, () => {
         const hoverResult = await hover(info, 'marker');
         assert(hoverResult);
         assert(MarkupContent.is(hoverResult.contents));
-        assert.strictEqual(hoverResult.contents.value, '```python\n(module) os\n```');
+        assert.strictEqual(hoverResult.contents.value, '```python\n(module) _typeshed\n```');
     });
     test('Completions', async () => {
         const code = `

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docstubs"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:39265ba9098b9b85d3d1a38ecba76cdc5383eb3454c6de782ef86204f5487d7e"
+content_hash = "sha256:7d58548dc3875b6d6961e45e6bf86753e9c877ae35cd8e67f07cb733d7ddb2e2"
 
 [[package]]
 name = "astroid"

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -30,7 +30,7 @@ def generate_docstubs():
     stubs_with_docs_path = Path("docstubs")
     if not stubs_with_docs_path.exists():
         copytree(stubs_path, stubs_with_docs_path, dirs_exist_ok=True)
-    docify(str(stubs_with_docs_path / "stdlib"), "--builtins-only", "--in-place")
+    docify(str(stubs_with_docs_path / "stdlib"), "--in-place")
 
 
 class Hook(BuildHookInterface):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
 ]
 # these deps are also needed in build-system.requires. see https://github.com/pdm-project/pdm/issues/2947
 docstubs = [
-    "docify @ git+https://github.com/AThePeanut4/docify@8896d7f4f3543b4f48ef8ebdec3b96250d5d1900", # https://github.com/AThePeanut4/docify/issues/3
+    "docify @ git+https://github.com/AThePeanut4/docify@6b5f3f7c7ec30ce16c3b67d55b052b487f8bcbc9", # https://github.com/AThePeanut4/docify/issues/3
     "libcst==1.1.0",
     "tqdm==4.66.4",
 ]
@@ -71,7 +71,7 @@ requires = [
     "nodejs-wheel>=20.13.1",
     # used in pdm_build.py:
     "typing_extensions>=4.12.2",
-    "docify @ git+https://github.com/AThePeanut4/docify@8896d7f4f3543b4f48ef8ebdec3b96250d5d1900",
+    "docify @ git+https://github.com/AThePeanut4/docify@6b5f3f7c7ec30ce16c3b67d55b052b487f8bcbc9",
     "libcst==1.1.0",
     "tqdm==4.66.4",
 ]


### PR DESCRIPTION
fixes #428