### PR TITLE
move pre-commit to a separate repo to prevent it from attempting to build the package when the hook gets installed

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,0 @@
-- id: basedpyright
-  name: basedpyright
-  description: 'pyright fork with various type checking improvements, improved vscode support and pylance features built into the language server'
-  entry: basedpyright
-  language: python
-  'types_or': [python, pyi]
-  require_serial: true
-  additional_dependencies: []
-  minimum_pre_commit_version: '2.9.2'

--- a/README.md
+++ b/README.md
@@ -399,20 +399,13 @@ integration with [pre-commit](https://pre-commit.com) is also supported.
 # .pre-commit-config.yaml
 
 repos:
-  - repo: https://github.com/DetachHead/basedpyright
-    rev: v1.8.0
+  - repo: https://github.com/DetachHead/basedpyright-pre-commit-mirror
+    rev: v1.13.0  # or whatever the latest version is at the time
     hooks:
     - id: basedpyright
 ```
 
-to ensure that basedpyright is able to find all of the dependencies in your
-virtual env, add the following to your `pyproject.toml`:
-
-```toml
-[tool.basedpyright]
-# ...
-venvPath = "."
-```
+for more information, see the documentation [here](https://github.com/DetachHead/basedpyright-pre-commit-mirror/blob/main/README.md)
 
 # recommended setup
 


### PR DESCRIPTION
fixes #430