### PR TITLE
docs: add dark mode theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,9 @@
                     depth: 4, // Headline depth, 1 - 6
                     hideOtherSidebarContent: true,
                 },
+                tabs: {
+                    theme: 'material'
+                }
             };
         </script>
         <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,12 @@
         <meta name="description" content="Description" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
         <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css" />
+        <link
+            rel="stylesheet"
+            href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+            title="docsify-darklight-theme"
+            type="text/css"
+        />
         <link rel="icon" href="img/favicon.ico" />
     </head>
     <body>
@@ -39,6 +45,10 @@
         <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
         <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
         <script src="//cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
+        <script
+            src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+            type="text/javascript"
+        ></script>
         <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
         <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-yml.min.js"></script>
         <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>


### PR DESCRIPTION
## Summary
 Add dark mode theme to current docsify docs with [docsify-darklight-theme](https://docsify-darklight-theme.boopathikumar.me/#/) and a switcher button
## Preview:
1. Dark 
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/4529b9f6-1cc4-493e-b194-3727924164c1">
2. Light
<img width="2032" alt="image" src="https://github.com/user-attachments/assets/922c96b3-14ec-4f7d-a8c7-78ca5614ef3a">
