### PR TITLE
docs: add hombrew install instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,11 @@ uv pip install basedpyright
 ```
 pip install basedpyright
 ```
+### **homebrew**
+
+```
+brew install basedpyright
+```
 
 <!-- tabs:end -->
 


### PR DESCRIPTION
This add installation instructions with [Homebrew](https://brew.sh).

closes #556

Waiting for https://github.com/Homebrew/homebrew-core/pull/180649 to be merged.
