### PR TITLE
change default `diagnosticMode` to `"workspace"` and send an error notification over LSP when an invalid value is set

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -16,7 +16,7 @@ The Pyright language server honors the following settings.
 
 **basedpyright.analysis.autoSearchPaths** [boolean]: Determines whether pyright automatically adds common search paths like "src" if there are no execution environments defined in the config file.
 
-**basedpyright.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files.
+**basedpyright.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files. Defaults to "workspace"
 
 **basedpyright.analysis.diagnosticSeverityOverrides** [map]: Allows a user to override the severity levels for individual diagnostic rules. "reportXXX" rules in the type check diagnostics settings in [configuration](configuration.md#type-check-diagnostics-settings) are supported. Use the rule name as a key and one of "error," "warning," "information," "true," "false," or "none" as value.
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -474,7 +474,15 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
     }
 
     protected isOpenFilesOnly(diagnosticMode: string): boolean {
-        return diagnosticMode !== 'workspace';
+        if (diagnosticMode === 'openFilesOnly') {
+            return true;
+        }
+        if (diagnosticMode === 'workspace') {
+            return false;
+        }
+        throw new Error(
+            `invalid diagnosticMode: "${diagnosticMode}". valid options are "workspace" or "openFilesOnly"`
+        );
     }
 
     protected getSeverityOverrides(value: string | boolean): DiagnosticSeverityOverrides | undefined {

--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -12,6 +12,8 @@ import {
     Command,
     Connection,
     ExecuteCommandParams,
+    MessageType,
+    ShowMessageNotification,
     WorkDoneProgressServerReporter,
 } from 'vscode-languageserver';
 
@@ -211,7 +213,10 @@ export abstract class RealLanguageServer extends LanguageServerBase {
                 }
             }
         } catch (error) {
-            this.console.error(`Error reading settings: ${error}`);
+            this.connection.sendNotification(ShowMessageNotification.type, {
+                message: error,
+                type: MessageType.Error,
+            });
         }
         return serverSettings;
     }

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -165,7 +165,6 @@ describe(`Basic language server tests`, () => {
                 },
                 value: {
                     typeCheckingMode: 'strict',
-                    diagnosticMode: 'workspace',
                 },
             },
         ];

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -149,7 +149,7 @@
                 },
                 "basedpyright.analysis.diagnosticMode": {
                     "type": "string",
-                    "default": "openFilesOnly",
+                    "default": "workspace",
                     "enum": [
                         "openFilesOnly",
                         "workspace"


### PR DESCRIPTION
fixes #559 