### PR TITLE
set `diagnosticMode` back to `"openFilesOnly"` by default

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -16,7 +16,7 @@ The Pyright language server honors the following settings.
 
 **basedpyright.analysis.autoSearchPaths** [boolean]: Determines whether pyright automatically adds common search paths like "src" if there are no execution environments defined in the config file.
 
-**basedpyright.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files. Defaults to "workspace"
+**basedpyright.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files. Defaults to "openFilesOnly"
 
 **basedpyright.analysis.diagnosticSeverityOverrides** [map]: Allows a user to override the severity levels for individual diagnostic rules. "reportXXX" rules in the type check diagnostics settings in [configuration](configuration.md#type-check-diagnostics-settings) are supported. Use the rule name as a key and one of "error," "warning," "information," "true," "false," or "none" as value.
 

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -165,6 +165,7 @@ describe(`Basic language server tests`, () => {
                 },
                 value: {
                     typeCheckingMode: 'strict',
+                    diagnosticMode: 'workspace',
                 },
             },
         ];

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -149,7 +149,7 @@
                 },
                 "basedpyright.analysis.diagnosticMode": {
                     "type": "string",
-                    "default": "workspace",
+                    "default": "openFilesOnly",
                     "enum": [
                         "openFilesOnly",
                         "workspace"


### PR DESCRIPTION
`"workspace"` is way too slow on a large project