### PR TITLE
fix broken stub docstrings from python 3.8 taking precedence over docstrings from 3.12

### DIFF
--- a/based_build/generateAllDocstubs.sh
+++ b/based_build/generateAllDocstubs.sh
@@ -1,4 +1,4 @@
-for pythonVersion in 3.8 3.9 3.10 3.11 3.12; do
+for pythonVersion in 3.12 3.11 3.10 3.9 3.8; do
     ./pw pdm use $pythonVersion --first
     ./pw pdm install --group=docstubs --no-self --no-default
     ./pw pdm run generate_docstubs


### PR DESCRIPTION
see https://github.com/AThePeanut4/docify/issues/10