### PR TITLE
fix unreachable, unused & deprecated diagnostic severity levels not working when set in the language server config

### DIFF
--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -18,6 +18,9 @@ export const enum DiagnosticSeverityOverrides {
     Warning = 'warning',
     Information = 'information',
     None = 'none',
+    Unused = 'unused',
+    Unreachable = 'unreachable',
+    Deprecated = 'deprecated',
 }
 
 export function getDiagnosticSeverityOverrides() {
@@ -26,6 +29,9 @@ export function getDiagnosticSeverityOverrides() {
         DiagnosticSeverityOverrides.Warning,
         DiagnosticSeverityOverrides.Information,
         DiagnosticSeverityOverrides.None,
+        DiagnosticSeverityOverrides.Unused,
+        DiagnosticSeverityOverrides.Unreachable,
+        DiagnosticSeverityOverrides.Deprecated,
     ];
 }
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1901,6 +1901,15 @@ export function parseDiagLevel(value: string | boolean): DiagnosticSeverityOverr
         case 'information':
             return DiagnosticSeverityOverrides.Information;
 
+        case 'unused':
+            return DiagnosticSeverityOverrides.Unused;
+
+        case 'unreachable':
+            return DiagnosticSeverityOverrides.Unreachable;
+
+        case 'deprecated':
+            return DiagnosticSeverityOverrides.Deprecated;
+
         default:
             return undefined;
     }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -489,6 +489,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
     protected getSeverityOverrides(value: string | boolean): DiagnosticSeverityOverrides | undefined {
         const enumValue = parseDiagLevel(value);
+        // TODO: this allows additional diagnostic severity levels (unreachable, unused & deprecated) on all rules
+        // in the lsp config. it should use the same logic as ConfigOptions._convertDiagnosticLevel instead
         if (!enumValue) {
             return undefined;
         }


### PR DESCRIPTION
fixes #555