### PR TITLE
make the python vscode extension a dependency of the basedpyright vscode extension as it's required to detect the python interpreter

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1719,6 +1719,9 @@
             }
         ]
     },
+    "extensionDependencies": [
+        "ms-python.python"
+    ],
     "scripts": {
         "clean": "shx rm -rf ./dist ./out README.md",
         "prepack": "npm run clean && shx cp ../../README.md . && shx cp ../../LICENSE.txt . && npm run build",


### PR DESCRIPTION
fixes #606 