### PR TITLE
improve fuzzy matching for auto-complete suggestions

### DIFF
--- a/packages/pyright-internal/src/common/stringUtils.ts
+++ b/packages/pyright-internal/src/common/stringUtils.ts
@@ -62,11 +62,26 @@ export function isPatternInSymbol(typedValue: string, symbolName: string): boole
     const symbolLower = symbolName.toLocaleLowerCase();
     const typedLength = typedLower.length;
     const symbolLength = symbolLower.length;
+    /** how many times we're allowed to skip a section of characters in symbolName
+    to find the next character in typedValue */
+    const skipLimit = Math.floor(typedLength / 4) + 1;
+    let countSkips = 0;
+    let inSkip = false;
     let typedPos = 0;
     let symbolPos = 0;
     while (typedPos < typedLength && symbolPos < symbolLength) {
         if (typedLower[typedPos] === symbolLower[symbolPos]) {
             typedPos += 1;
+            inSkip = false;
+        }
+        else {  // character doesn't match
+            if (! inSkip) {
+                if (countSkips >= skipLimit) {
+                    return false;
+                }
+                ++countSkips;
+                inSkip = true;
+            }
         }
         symbolPos += 1;
     }

--- a/packages/pyright-internal/src/common/stringUtils.ts
+++ b/packages/pyright-internal/src/common/stringUtils.ts
@@ -73,9 +73,9 @@ export function isPatternInSymbol(typedValue: string, symbolName: string): boole
         if (typedLower[typedPos] === symbolLower[symbolPos]) {
             typedPos += 1;
             inSkip = false;
-        }
-        else {  // character doesn't match
-            if (! inSkip) {
+        } else {
+            // character doesn't match
+            if (!inSkip) {
                 if (countSkips >= skipLimit) {
                     return false;
                 }

--- a/packages/pyright-internal/src/tests/fourslash/completions.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.fourslash.ts
@@ -22,14 +22,6 @@ await helper.verifyCompletion('exact', 'markdown', {
                 label: 'gmtime',
                 kind: Consts.CompletionItemKind.Function,
             },
-            {
-                label: 'clock_gettime',
-                kind: Consts.CompletionItemKind.Function,
-            },
-            {
-                label: 'clock_gettime_ns',
-                kind: Consts.CompletionItemKind.Function,
-            },
         ],
     },
     marker2: { completions: [{ label: 'aaaaaa', kind: Consts.CompletionItemKind.Variable }] },

--- a/packages/pyright-internal/src/tests/stringUtils.test.ts
+++ b/packages/pyright-internal/src/tests/stringUtils.test.ts
@@ -30,6 +30,22 @@ test('stringUtils isPatternInSymbol', () => {
 
     assert.equal(utils.isPatternInSymbol('abcd', 'abcd'), true);
     assert.equal(utils.isPatternInSymbol('abc', 'abcd'), true);
+    assert.equal(utils.isPatternInSymbol('abc', 'xyzabcd'), true);
+    assert.equal(utils.isPatternInSymbol('abc', 'axbcd'), true);
+
+    // 2 skips is too many skips for a short typedValue.
+    assert.equal(utils.isPatternInSymbol('abc', 'xyzabxcd'), false);
+    assert.equal(utils.isPatternInSymbol('abc', 'axbxc'), false);
+
+    // Longer typedValues allow more skips.
+    assert.equal(utils.isPatternInSymbol('abcd', 'xyzabcxd'), true);
+    assert.equal(utils.isPatternInSymbol('abcd', 'axbxcd'), true);
+    assert.equal(utils.isPatternInSymbol('abcd', 'xabxcxd'), false);
+    assert.equal(utils.isPatternInSymbol('abcd', 'abxcxd'), true);
+    assert.equal(utils.isPatternInSymbol('abcd', 'axbcxdxyz'), true);
+    assert.equal(utils.isPatternInSymbol('abcdefgh', 'abcdxyzefxghxyz'), true);
+    assert.equal(utils.isPatternInSymbol('abcdefgh', 'xabcdxefxghxyz'), true);
+    assert.equal(utils.isPatternInSymbol('abcdefgh', 'xabcxdxefxghxyz'), false);
 
     assert.equal(utils.isPatternInSymbol('ABCD', 'abcd'), true);
     assert.equal(utils.isPatternInSymbol('ABC', 'abcd'), true);


### PR DESCRIPTION
doesn't allow skipping as many sections of characters in the string matching

When the user types `sleep`, it will no longer give `SimpleNamespace` as a suggestion.
`SimpleNamespace`
`^   ^^   ^ ^`
When the user types `aaaaa`, it will no longer give `AbstractAsyncContextManager` as a suggestion.
And you can see an example changed in the unit tests:
`time.gm` only suggests `time.gmtime` and no longer suggests `time.clock_gettime` or `time.clock_gettime_ns`

added unit tests for the changed function