### PR TITLE
Improve import suggestion code actions by showing more relevant suggestions first

### DIFF
--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -205,6 +205,24 @@ function stableSortIndices<T>(array: readonly T[], indices: number[], comparer: 
     indices.sort((x, y) => comparer(array[x], array[y]) || compareValues(x, y));
 }
 
+/**
+ * used to create sorter functions for {@link Array.sort} where the values can only be compared by
+ * whether they're greater, less than or equal.
+ * @param comparator function to compare two values. return `true` if the next item is greater than
+ * the previous item, or `false` if it's less than or equal to the previous function. gets called twice
+ * with the arguments reversed if it didn't return `true` the first time
+ * @returns a number to be used by {@link Array.sort} to sort items in an array
+ */
+export const sorter = <T>(prev: T, next: T, comparator: (prev: T, next: T) => boolean) => {
+    if (comparator(prev, next)) {
+        return 1;
+    }
+    if (comparator(next, prev)) {
+        return -1;
+    }
+    return 0;
+};
+
 export function map<T, U>(array: readonly T[], f: (x: T, i: number) => U): U[];
 export function map<T, U>(array: readonly T[] | undefined, f: (x: T, i: number) => U): U[] | undefined;
 export function map<T, U>(array: readonly T[] | undefined, f: (x: T, i: number) => U): U[] | undefined {

--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -133,16 +133,12 @@ export class CodeActionProvider {
                 if (!suggestedImport.data) {
                     continue;
                 }
-                completer.resolveCompletionItem(suggestedImport);
-                if (!completer.itemToResolve) {
-                    continue;
-                }
                 let textEdits: TextEdit[] = [];
-                if (completer.itemToResolve.textEdit && 'range' in completer.itemToResolve.textEdit) {
-                    textEdits.push(completer.itemToResolve.textEdit);
+                if (suggestedImport.textEdit && 'range' in suggestedImport.textEdit) {
+                    textEdits.push(suggestedImport.textEdit);
                 }
-                if (completer.itemToResolve.additionalTextEdits) {
-                    textEdits = textEdits.concat(completer.itemToResolve.additionalTextEdits);
+                if (suggestedImport.additionalTextEdits) {
+                    textEdits = textEdits.concat(suggestedImport.additionalTextEdits);
                 }
                 if (textEdits.length === 0) {
                     continue;

--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -129,7 +129,9 @@ export class CodeActionProvider {
                 },
                 token
             );
-            for (const suggestedImport of completer.getCompletions()?.items ?? []) {
+            // i think code actions show up as the most recently added one first, so to prevent the least relevant results
+            // from appearing at the top, we reverse the list
+            for (const suggestedImport of completer.getCompletions()?.items.reverse() ?? []) {
                 if (!suggestedImport.data) {
                     continue;
                 }


### PR DESCRIPTION
- remove useless call that was resolving more info about each suggestion that wasn't being used, which was making it slower to resolve them all
- sort suggestions by their `sortText` and move exact matches to the top. this seems to be something that completions does automatically, but needs to be done manually for code actions

fixes #587