### PR TITLE
improved narrowing of generics

### DIFF
--- a/docs/benefits-over-pyright/improved-generic-narrowing.md
+++ b/docs/benefits-over-pyright/improved-generic-narrowing.md
@@ -1,0 +1,85 @@
+# improved type narrowing
+
+when narrowing a type using an `isinstance` check, there's no way for the type checker to narrow its type variables, so pyright just narrows them to ["Unknown"](../usage/mypy-comparison.md#unknown-type-and-strict-mode)):
+
+```py
+def foo(value: object):
+    if isinstance(value, list):
+        reveal_type(value) # list[Unknown]
+```
+
+this makes sense in cases where the generic is invariant and there's no other way to represent any of its possibilities. for example if it were to be narrowed to `list[object]`, you wouldn't be able to assign `list[int]` to it. however in cases where the generic is covariant, contravariant, or uses constraints, it can be narrowed more accurately.
+
+basedpyright introduces the new [`strictGenericNarrowing`](../configuration/config-files.md#strictGenericNarrowing) setting to address this. the following sections explain how this new behavior effects different types of generics.
+
+## narrowing of covariant generics
+
+when a type variable is covariant, its widest possible type is its bound, which defaults to `object`.
+
+when `strictGenericNarrowing` is enabled, if a generic is covariant and does not have a bound, it gets narrowed to `object` instead of "Unknown":
+
+```py
+T_co = TypeVar("T_co", covariant=True)
+
+class Foo(Generic[T_co]):
+    ...
+
+def foo(value: object):
+    if isinstance(value, Foo):
+        reveal_type(value)  # Foo[object]
+```
+
+if the generic does have a bound, it gets narrowed to that bound instead:
+
+```py
+T_co = TypeVar("T_co", bound=int | str, covariant=True)
+
+class Foo(Generic[T_co]):
+    ...
+
+def foo(value: object):
+    if isinstance(value, Foo):
+        reveal_type(value)  # Foo[int | str]
+```
+
+## narrowing of contravariant generics
+
+when a type variable is contravariant its widest possible type is `Never`, so when `strictGenericNarrowing` is enabled, contravariant generics get narrowed to `Never` instead of "Unknown":
+
+```py
+T_contra = TypeVar("T_contra", bound=int | str, covariant=True)
+
+class Foo(Generic[T_contra]):
+    ...
+
+def foo(value: object):
+    if isinstance(value, Foo):
+        reveal_type(value)  # Foo[Never]
+```
+
+## narrowing of constraints
+
+when a type variable uses constraints, the rules of variance do not apply - see [this issue](https://github.com/DetachHead/basedpyright/issues/893) for more information. instead, a constraint declares that the generic must be resolved to be exactly one of the types specified.
+
+when `strictGenericNarrowing` is enabled, constrained generics are narrowed to a union of all possibilities:
+
+```py
+class Foo[T: (int, str)]:
+    ...
+
+def foo(value: object):
+    if isinstance(value, Foo):
+        reveal_type(value)  # Foo[int] | Foo[str]
+```
+
+this also works when there's more than one constrained type variable - it creates a union of all possible combinations:
+
+```py
+
+class Foo[T: (int, str), U: (float, bytes)]:
+    ...
+
+def foo(value: object):
+    if isinstance(value, Foo):
+        reveal_type(value)  #  Foo[int, float] | Foo[int, bytes] | Foo[str, float] | Foo[str, bytes]
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ The following settings determine how different types should be evaluated.
 
 ### basedpyright exclusive settings
 
-- <a name="strictGenericNarrowing"></a> **strictGenericNarrowing** [boolean]: When a type is narrowed in such a way that its type parameters are not known (eg. using an `isinstance` check), basedpyright will resolve the type parameter to the generic's bound or constraint instead of `Any`.
+- <a name="strictGenericNarrowing"></a> **strictGenericNarrowing** [boolean]: When a type is narrowed in such a way that its type parameters are not known (eg. using an `isinstance` check), basedpyright will resolve the type parameter to the generic's bound or constraint instead of `Any`. [more info](../benefits-over-pyright/improved-generic-narrowing.md)
 
 ## Diagnostic Categories
 
@@ -269,27 +269,27 @@ The following settings allow more fine grained control over the **typeCheckingMo
 
 ### basedpyright exclusive settings
 
-- <a name="reportUnreachable"></a> **reportUnreachable** [boolean or string, optional]: Generate or suppress diagnostics for unreachable code.
+- <a name="reportUnreachable"></a> **reportUnreachable** [boolean or string, optional]: Generate or suppress diagnostics for unreachable code. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportunreachable)
 
-- <a name="reportAny"></a> **reportAny** [boolean or string, optional]: Generate or suppress diagnostics for expressions that have the `Any` type. this accounts for all scenarios not covered by the `reportUnknown*` rules (since "Unknown" isn't a real type, but a distinction pyright makes to disallow the `Any` type only in certain circumstances).
+- <a name="reportAny"></a> **reportAny** [boolean or string, optional]: Generate or suppress diagnostics for expressions that have the `Any` type. this accounts for all scenarios not covered by the `reportUnknown*` rules (since "Unknown" isn't a real type, but a distinction pyright makes to disallow the `Any` type only in certain circumstances). [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportany)
 
-- <a name="reportExplicitAny"></a> **reportExplicitAny** [boolean or string, optional]: Ban all explicit usages of the `Any` type. While `reportAny` bans expressions typed as `Any`, this rule bans using the `Any` type directly eg. in a type annotation.
+- <a name="reportExplicitAny"></a> **reportExplicitAny** [boolean or string, optional]: Ban all explicit usages of the `Any` type. While `reportAny` bans expressions typed as `Any`, this rule bans using the `Any` type directly eg. in a type annotation. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportexplicitany)
 
-- <a name="reportIgnoreCommentWithoutRule"></a> **reportIgnoreCommentWithoutRule** [boolean or string, optional]: Enforce that all `# type:ignore`/`# pyright:ignore` comments specify a rule in brackets (eg. `# pyright:ignore[reportAny]`)
+- <a name="reportIgnoreCommentWithoutRule"></a> **reportIgnoreCommentWithoutRule** [boolean or string, optional]: Enforce that all `# type:ignore`/`# pyright:ignore` comments specify a rule in brackets (eg. `# pyright:ignore[reportAny]`). [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportignorecommentwithoutrule)
 
-- <a name="reportPrivateLocalImportUsage"></a> **reportPrivateLocalImportUsage** [boolean or string, optional]: Generate or suppress diagnostics for use of a symbol from a local module that is not meant to be exported from that module. Like `reportPrivateImportUsage` but also checks imports from your own code.
+- <a name="reportPrivateLocalImportUsage"></a> **reportPrivateLocalImportUsage** [boolean or string, optional]: Generate or suppress diagnostics for use of a symbol from a local module that is not meant to be exported from that module. Like `reportPrivateImportUsage` but also checks imports from your own code. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportprivatelocalimportusage)
 
-- <a name="reportImplicitRelativeImport"></a> **reportImplicitRelativeImport** [boolean or string, optional]: Generate or suppress diagnostics for non-relative imports that do not specify the full path to the module.
+- <a name="reportImplicitRelativeImport"></a> **reportImplicitRelativeImport** [boolean or string, optional]: Generate or suppress diagnostics for non-relative imports that do not specify the full path to the module. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportimplicitrelativeimport)
 
-- <a name="reportInvalidCast"></a> **reportInvalidCast** [boolean or string, optional]: Generate or suppress diagnostics for `cast`s to non-overlapping types.
+- <a name="reportInvalidCast"></a> **reportInvalidCast** [boolean or string, optional]: Generate or suppress diagnostics for `cast`s to non-overlapping types. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportinvalidcast)
 
-- <a name="reportUnsafeMultipleInheritance"></a> **reportUnsafeMultipleInheritance** [boolean or string, optional]: Generate or suppress diagnostics for classes that inherit from multiple base classes with an `__init__` or `__new__` method, which is unsafe because those additional constructors may either never get called or get called with invalid arguments.
+- <a name="reportUnsafeMultipleInheritance"></a> **reportUnsafeMultipleInheritance** [boolean or string, optional]: Generate or suppress diagnostics for classes that inherit from multiple base classes with an `__init__` or `__new__` method, which is unsafe because those additional constructors may either never get called or get called with invalid arguments. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportunsafemultipleinheritance)
 
 - <a name="reportUnusedParameter"></a> **reportUnusedParameter** [boolean or string, optional]: Generate or suppress diagnostics for unused function parameters.
 
-- <a name="reportImplicitAbstractClass"></a> **reportImplicitAbstractClass** [boolean or string, optional]: Diagnostics for classes that extend abstract classes without also explicitly declaring themselves as abstract or implementing all of the required abstract methods.
+- <a name="reportImplicitAbstractClass"></a> **reportImplicitAbstractClass** [boolean or string, optional]: Diagnostics for classes that extend abstract classes without also explicitly declaring themselves as abstract or implementing all of the required abstract methods. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportimplicitabstractclass)
 
-- <a name="reportUnannotatedClassAttribute"></a> **reportUnannotatedClassAttribute** [boolean or string, optional]: Generate or suppress diagnostics for class attribute declarations that do not have a type annotation. These are unsafe because for performance reasons, subtypes are not validated to ensure that they are compatible with the supertype.
+- <a name="reportUnannotatedClassAttribute"></a> **reportUnannotatedClassAttribute** [boolean or string, optional]: Generate or suppress diagnostics for class attribute declarations that do not have a type annotation. These are unsafe because for performance reasons, subtypes are not validated to ensure that they are compatible with the supertype. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportunannotatedclassattribute)
 
 ## Discouraged options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,10 @@ The following settings control the *environment* in which basedpyright will chec
 
 - **useLibraryCodeForTypes** [boolean]: Determines whether pyright reads, parses and analyzes library code to extract type information in the absence of type stub files. Type information will typically be incomplete. We recommend using type stubs where possible. The default value for this option is true.
 
+### basedpyright exclusive settings
+
+- <a name="failOnWarnings"></a> **failOnWarnings** [boolean]: Whether to exit with a non-zero exit code in the CLI if any `"warning"` diagnostics are reported. Has no effect on the language server. This is equivalent to the `--warnings` CLI argument.
+
 ## Type Evaluation Settings
 
 The following settings determine how different types should be evaluated.
@@ -68,6 +72,10 @@ The following settings determine how different types should be evaluated.
 - <a name="enableExperimentalFeatures"></a> **enableExperimentalFeatures** [boolean]: Enables a set of experimental (mostly undocumented) features that correspond to proposed or exploratory changes to the Python typing standard. These features will likely change or be removed, so they should not be used except for experimentation purposes.
 
 - <a name="disableBytesTypePromotions"></a> **disableBytesTypePromotions** [boolean]: Disables legacy behavior where `bytearray` and `memoryview` are considered subtypes of `bytes`. [PEP 688](https://peps.python.org/pep-0688/#no-special-meaning-for-bytes) deprecates this behavior, but this switch is provided to restore the older behavior.
+
+### basedpyright exclusive settings
+
+- <a name="improvedGenericNarrowing"></a> **improvedGenericNarrowing** [boolean]: When a type is narrowed in such a way that its type parameters are not known (eg. using an `isinstance` check), basedpyright will resolve the type parameter to the generic's bound or constraint instead of `Any`.
 
 ## Diagnostic Categories
 
@@ -259,11 +267,7 @@ The following settings allow more fine grained control over the **typeCheckingMo
 
 - <a name="reportShadowedImports"></a> **reportShadowedImports** [boolean or string, optional]: Generate or suppress diagnostics for files that are overriding a module in the stdlib.
 
-## Based options
-
-the following additional options are not available in regular pyright:
-
-- <a name="failOnWarnings"></a> **failOnWarnings** [boolean]: Whether to exit with a non-zero exit code in the CLI if any `"warning"` diagnostics are reported. Has no effect on the language server. This is equivalent to the `--warnings` CLI argument.
+### basedpyright exclusive settings
 
 - <a name="reportUnreachable"></a> **reportUnreachable** [boolean or string, optional]: Generate or suppress diagnostics for unreachable code.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ The following settings determine how different types should be evaluated.
 
 ### basedpyright exclusive settings
 
-- <a name="improvedGenericNarrowing"></a> **improvedGenericNarrowing** [boolean]: When a type is narrowed in such a way that its type parameters are not known (eg. using an `isinstance` check), basedpyright will resolve the type parameter to the generic's bound or constraint instead of `Any`.
+- <a name="strictGenericNarrowing"></a> **strictGenericNarrowing** [boolean]: When a type is narrowed in such a way that its type parameters are not known (eg. using an `isinstance` check), basedpyright will resolve the type parameter to the generic's bound or constraint instead of `Any`.
 
 ## Diagnostic Categories
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test-python": "uv run --no-sync pytest tests",
         "generate-docstubs": "uv run --no-sync based_build/generate_docstubs.py",
         "localization-helper": "uv run --no-sync based_build/localization_helper.py",
-        "docs": "uv run mkdocs serve"
+        "docs": "uv run --no-sync mkdocs serve"
     },
     "devDependencies": {
         "@detachhead/ts-helpers": "^16.2.0",

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3793,7 +3793,12 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        const classTypeList = getIsInstanceClassTypes(this._evaluator, arg1Type, arg0Type);
+        const classTypeList = getIsInstanceClassTypes(
+            this._evaluator,
+            arg1Type,
+            arg0Type,
+            this._fileInfo.diagnosticRuleSet.improvedGenericNarrowing
+        );
         if (!classTypeList) {
             return;
         }

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3797,7 +3797,7 @@ export class Checker extends ParseTreeWalker {
             this._evaluator,
             arg1Type,
             arg0Type,
-            this._fileInfo.diagnosticRuleSet.improvedGenericNarrowing
+            this._fileInfo.diagnosticRuleSet.strictGenericNarrowing
         );
         if (!classTypeList) {
             return;

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -3793,7 +3793,7 @@ export class Checker extends ParseTreeWalker {
             return;
         }
 
-        const classTypeList = getIsInstanceClassTypes(this._evaluator, arg1Type);
+        const classTypeList = getIsInstanceClassTypes(this._evaluator, arg1Type, arg0Type);
         if (!classTypeList) {
             return;
         }

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -775,7 +775,13 @@ function narrowTypeBasedOnClassPattern(
     if (isClass(exprType) && !exprType.props?.typeAliasInfo) {
         exprType = ClassType.cloneRemoveTypePromotions(exprType);
         evaluator.inferVarianceForClass(exprType);
-        exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType(), evaluator.getObjectType());
+        exprType = specializeWithUnknownTypeArgs(
+            exprType,
+            evaluator.getTupleClassType(),
+            // for backwards compatibility with bacly typed code, we don't specialize using variance if the type we're
+            // narrowing is Any/Unknown
+            isAnyOrUnknown(type) || isPartlyUnknown(type) ? undefined : evaluator.getObjectType()
+        );
     }
 
     // Are there any positional arguments? If so, try to get the mappings for

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -780,7 +780,7 @@ function narrowTypeBasedOnClassPattern(
         exprType = specializeWithUnknownTypeArgs(
             exprType,
             evaluator.getTupleClassType(),
-            shouldUseVarianceForSpecialization(type, getFileInfo(pattern).diagnosticRuleSet.improvedGenericNarrowing)
+            shouldUseVarianceForSpecialization(type, getFileInfo(pattern).diagnosticRuleSet.strictGenericNarrowing)
                 ? evaluator.getObjectType()
                 : undefined
         );

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -774,6 +774,7 @@ function narrowTypeBasedOnClassPattern(
     // specialize it with Unknown type arguments.
     if (isClass(exprType) && !exprType.props?.typeAliasInfo) {
         exprType = ClassType.cloneRemoveTypePromotions(exprType);
+        evaluator.inferVarianceForClass(exprType);
         exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType(), evaluator.getObjectType());
     }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -28,6 +28,7 @@ import {
     PatternSequenceNode,
     PatternValueNode,
 } from '../parser/parseNodes';
+import { getFileInfo } from './analyzerNodeInfo';
 import { CodeFlowReferenceExpressionNode } from './codeFlowTypes';
 import { addConstraintsForExpectedType } from './constraintSolver';
 import { ConstraintTracker } from './constraintTracker';
@@ -779,7 +780,9 @@ function narrowTypeBasedOnClassPattern(
         exprType = specializeWithUnknownTypeArgs(
             exprType,
             evaluator.getTupleClassType(),
-            shouldUseVarianceForSpecialization(type) ? evaluator.getObjectType() : undefined
+            shouldUseVarianceForSpecialization(type, getFileInfo(pattern).diagnosticRuleSet.improvedGenericNarrowing)
+                ? evaluator.getObjectType()
+                : undefined
         );
     }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -84,6 +84,7 @@ import {
     mapSubtypes,
     partiallySpecializeType,
     preserveUnknown,
+    shouldUseVarianceForSpecialization,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
     transformPossibleRecursiveTypeAlias,
@@ -778,9 +779,7 @@ function narrowTypeBasedOnClassPattern(
         exprType = specializeWithUnknownTypeArgs(
             exprType,
             evaluator.getTupleClassType(),
-            // for backwards compatibility with bacly typed code, we don't specialize using variance if the type we're
-            // narrowing is Any/Unknown
-            isAnyOrUnknown(type) || isPartlyUnknown(type) ? undefined : evaluator.getObjectType()
+            shouldUseVarianceForSpecialization(type) ? evaluator.getObjectType() : undefined
         );
     }
 

--- a/packages/pyright-internal/src/analyzer/patternMatching.ts
+++ b/packages/pyright-internal/src/analyzer/patternMatching.ts
@@ -774,7 +774,7 @@ function narrowTypeBasedOnClassPattern(
     // specialize it with Unknown type arguments.
     if (isClass(exprType) && !exprType.props?.typeAliasInfo) {
         exprType = ClassType.cloneRemoveTypePromotions(exprType);
-        exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType());
+        exprType = specializeWithUnknownTypeArgs(exprType, evaluator.getTupleClassType(), evaluator.getObjectType());
     }
 
     // Are there any positional arguments? If so, try to get the mappings for

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -628,7 +628,7 @@ export function getTypeNarrowingCallback(
                         evaluator,
                         arg1Type,
                         evaluator.getTypeOfExpression(arg0Expr).type,
-                        getFileInfo(testExpression).diagnosticRuleSet.improvedGenericNarrowing
+                        getFileInfo(testExpression).diagnosticRuleSet.strictGenericNarrowing
                     );
                     const isIncomplete = !!callTypeResult.isIncomplete || !!arg1TypeResult.isIncomplete;
 
@@ -1133,7 +1133,7 @@ export function getIsInstanceClassTypes(
     evaluator: TypeEvaluator,
     argType: Type,
     typeToNarrow: Type,
-    improvedGenericNarrowing: boolean
+    strictGenericNarrowing: boolean
 ): (ClassType | TypeVarType | FunctionType)[] | undefined {
     let foundNonClassType = false;
     const classTypeList: (ClassType | TypeVarType | FunctionType)[] = [];
@@ -1143,7 +1143,7 @@ export function getIsInstanceClassTypes(
         types.forEach((type) => {
             const subtypes: Type[] = [];
             if (isClass(type)) {
-                const useVariance = shouldUseVarianceForSpecialization(typeToNarrow, improvedGenericNarrowing);
+                const useVariance = shouldUseVarianceForSpecialization(typeToNarrow, strictGenericNarrowing);
                 if (useVariance) {
                     evaluator.inferVarianceForClass(type);
                 }

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1137,18 +1137,20 @@ export function getIsInstanceClassTypes(
 ): (ClassType | TypeVarType | FunctionType)[] | undefined {
     let foundNonClassType = false;
     const classTypeList: (ClassType | TypeVarType | FunctionType)[] = [];
-    const useVarianceForSpecialization = shouldUseVarianceForSpecialization(typeToNarrow, improvedGenericNarrowing);
     // Create a helper function that returns a list of class types or
     // undefined if any of the types are not valid.
     const addClassTypesToList = (types: Type[]) => {
         types.forEach((type) => {
             const subtypes: Type[] = [];
             if (isClass(type)) {
-                evaluator.inferVarianceForClass(type);
+                const useVariance = shouldUseVarianceForSpecialization(typeToNarrow, improvedGenericNarrowing);
+                if (useVariance) {
+                    evaluator.inferVarianceForClass(type);
+                }
                 type = specializeWithUnknownTypeArgs(
                     type,
                     evaluator.getTupleClassType(),
-                    useVarianceForSpecialization ? evaluator.getObjectType() : undefined
+                    useVariance ? evaluator.getObjectType() : undefined
                 );
 
                 doForEachSubtype(type, (subtype) => {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -627,7 +627,8 @@ export function getTypeNarrowingCallback(
                     const classTypeList = getIsInstanceClassTypes(
                         evaluator,
                         arg1Type,
-                        evaluator.getTypeOfExpression(arg0Expr).type
+                        evaluator.getTypeOfExpression(arg0Expr).type,
+                        getFileInfo(testExpression).diagnosticRuleSet.improvedGenericNarrowing
                     );
                     const isIncomplete = !!callTypeResult.isIncomplete || !!arg1TypeResult.isIncomplete;
 
@@ -1131,11 +1132,12 @@ function narrowTypeForIsEllipsis(evaluator: TypeEvaluator, node: ExpressionNode,
 export function getIsInstanceClassTypes(
     evaluator: TypeEvaluator,
     argType: Type,
-    typeToNarrow: Type
+    typeToNarrow: Type,
+    improvedGenericNarrowing: boolean
 ): (ClassType | TypeVarType | FunctionType)[] | undefined {
     let foundNonClassType = false;
     const classTypeList: (ClassType | TypeVarType | FunctionType)[] = [];
-    const useVarianceForSpecialization = shouldUseVarianceForSpecialization(typeToNarrow);
+    const useVarianceForSpecialization = shouldUseVarianceForSpecialization(typeToNarrow, improvedGenericNarrowing);
     // Create a helper function that returns a list of class types or
     // undefined if any of the types are not valid.
     const addClassTypesToList = (types: Type[]) => {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -82,7 +82,6 @@ import {
     isMetaclassInstance,
     isNoneInstance,
     isNoneTypeClass,
-    isPartlyUnknown,
     isProperty,
     isTupleClass,
     isTupleGradualForm,
@@ -92,6 +91,7 @@ import {
     makeTypeVarsFree,
     mapSubtypes,
     MemberAccessFlags,
+    shouldUseVarianceForSpecialization,
     specializeTupleClass,
     specializeWithUnknownTypeArgs,
     stripTypeForm,
@@ -1135,11 +1135,7 @@ export function getIsInstanceClassTypes(
 ): (ClassType | TypeVarType | FunctionType)[] | undefined {
     let foundNonClassType = false;
     const classTypeList: (ClassType | TypeVarType | FunctionType)[] = [];
-    /**
-     * if the type we're narrowing is Any or Unknown, we don't want to specialize using the
-     * variance/bound for compatibility with less strictly typed code (cringe)
-     */
-    const useVarianceForSpecialization = !isAnyOrUnknown(typeToNarrow) && !isPartlyUnknown(typeToNarrow);
+    const useVarianceForSpecialization = shouldUseVarianceForSpecialization(typeToNarrow);
     // Create a helper function that returns a list of class types or
     // undefined if any of the types are not valid.
     const addClassTypesToList = (types: Type[]) => {

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1135,7 +1135,12 @@ export function getIsInstanceClassTypes(
     const addClassTypesToList = (types: Type[]) => {
         types.forEach((subtype) => {
             if (isClass(subtype)) {
-                subtype = specializeWithUnknownTypeArgs(subtype, evaluator.getTupleClassType());
+                evaluator.inferVarianceForClass(subtype);
+                subtype = specializeWithUnknownTypeArgs(
+                    subtype,
+                    evaluator.getTupleClassType(),
+                    evaluator.getObjectType()
+                );
 
                 if (isInstantiableClass(subtype) && ClassType.isBuiltIn(subtype, 'Callable')) {
                     subtype = convertToInstantiable(getUnknownTypeForCallable());

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1086,7 +1086,7 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
  * variance/bound for compatibility with less strictly typed code (cringe)
  */
 export const shouldUseVarianceForSpecialization = (type: Type) =>
-    (type.category !== TypeCategory.Class || type.shared.typeParams.length === 0);
+    type.category !== TypeCategory.Class || type.shared.typeParams.length === 0;
 
 /**
  * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1083,8 +1083,8 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
  * If the type we're narrowing already has type parameters,
  * there's no need to use variance for specialization.
  */
-export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, improvedGenericNarrowing: boolean) => {
-    if (!improvedGenericNarrowing) {
+export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, strictGenericNarrowing: boolean) => {
+    if (!strictGenericNarrowing) {
         return false;
     }
     return allSubtypes(
@@ -1098,12 +1098,12 @@ export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, improvedG
 
 /**
  * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its
- * widest possible type if its variance is known and {@link objectTypeForImprovedGenericNarrowing} is provided (`object` if
+ * widest possible type if its variance is known and {@link objectTypeForstrictGenericNarrowing} is provided (`object` if
  * the bound if covariant, `Never` if contravariant). see docstring on {@link getUnknownForTypeVar} for more info
  *
  * @param tupleClassType the builtin `tuple` type for special-casing tuples. needs to be passed so that this
  * module doesn't depend on `typeEvaluator.ts`
- * @param objectTypeForImprovedGenericNarrowing
+ * @param objectTypeForstrictGenericNarrowing
  * the builtin `object` type to be returned if the type var is covariant.
  * needs to be passed so that this module doesn't depend on `typeEvaluator.ts`. note that
  * `evaluator.inferVarianceForClass` needs to be called on {@link type} first if passing this parameter.
@@ -1115,7 +1115,7 @@ export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, improvedG
 export function specializeWithUnknownTypeArgs(
     type: ClassType,
     tupleClassType?: ClassType,
-    objectTypeForImprovedGenericNarrowing?: Type
+    objectTypeForstrictGenericNarrowing?: Type
 ): ClassType | UnionType {
     if (type.shared.typeParams.length === 0) {
         return type;
@@ -1131,7 +1131,7 @@ export function specializeWithUnknownTypeArgs(
             !!type.priv.includeSubclasses
         );
     }
-    if (objectTypeForImprovedGenericNarrowing) {
+    if (objectTypeForstrictGenericNarrowing) {
         const result = UnionType.create();
         const constraintCombinations = new Array<Type[]>();
 
@@ -1146,7 +1146,7 @@ export function specializeWithUnknownTypeArgs(
                 }
             } else {
                 currentConstraints.push(
-                    getUnknownForTypeVar(typeParam, tupleClassType, objectTypeForImprovedGenericNarrowing)
+                    getUnknownForTypeVar(typeParam, tupleClassType, objectTypeForstrictGenericNarrowing)
                 );
             }
         }

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -778,9 +778,7 @@ export function someSubtypes(type: Type, callback: (type: Type) => boolean): boo
 
 export function allSubtypes(type: Type, callback: (type: Type) => boolean): boolean {
     if (isUnion(type)) {
-        return type.priv.subtypes.every((subtype) => {
-            callback(subtype);
-        });
+        return type.priv.subtypes.every((subtype) => callback(subtype));
     } else {
         return callback(type);
     }
@@ -1085,8 +1083,18 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
  * If the type we're narrowing already has type parameters,
  * there's no need to use variance for specialization.
  */
-export const shouldUseVarianceForSpecialization = (type: Type, improvedGenericNarrowing: boolean) =>
-    improvedGenericNarrowing && (type.category !== TypeCategory.Class || type.shared.typeParams.length === 0);
+export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, improvedGenericNarrowing: boolean) => {
+    if (!improvedGenericNarrowing) {
+        return false;
+    }
+    return allSubtypes(
+        typeToNarrow,
+        (subtype) =>
+            subtype.category !== TypeCategory.Class ||
+            // !ClassType.isSameGenericClass(subtype, narrowToType) ||
+            subtype.shared.typeParams.length === 0
+    );
+};
 
 /**
  * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1082,8 +1082,8 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
 }
 
 /**
- * if the type we're narrowing is Any or Unknown, we don't want to specialize using the
- * variance/bound for compatibility with less strictly typed code (cringe)
+ * If the type we're narrowing already has type parameters,
+ * there's no need to use variance for specialization.
  */
 export const shouldUseVarianceForSpecialization = (type: Type) =>
     type.category !== TypeCategory.Class || type.shared.typeParams.length === 0;

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1081,9 +1081,24 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
     return scopeIds;
 }
 
-// Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs
-// or TypeVarTuples).
-export function specializeWithUnknownTypeArgs(type: ClassType, tupleClassType?: ClassType): ClassType {
+/**
+ * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its
+ * widest possible type if its variance is known and {@link objectTypeForVarianceCheck} is provided (`object` if
+ * the bound if covariant, `Never` if contravariant). see docstring on {@link getUnknownForTypeVar} for more info
+ *
+ * @param tupleClassType the builtin `tuple` type for special-casing tuples. needs to be passed so that this
+ * module doesn't depend on `typeEvaluator.ts`
+ * @param objectTypeForVarianceCheck the builtin `object` type to be returned if the type var is covariant.
+ * passing this parameter enables the variance check which allows it to return a better result than just "Unknown"
+ * in cases where the variance is known (ie. `object` or its bound if it's covariant, and `Never` if it's
+ * contravariant). needs to be passed so that this module doesn't depend on `typeEvaluator.ts`. note that
+ * `evaluator.inferVarianceForClass` needs to be called on {@link type} first if passing this parameter
+ */
+export function specializeWithUnknownTypeArgs(
+    type: ClassType,
+    tupleClassType?: ClassType,
+    objectTypeForVarianceCheck?: Type
+): ClassType {
     if (type.shared.typeParams.length === 0) {
         return type;
     }
@@ -1101,14 +1116,32 @@ export function specializeWithUnknownTypeArgs(type: ClassType, tupleClassType?: 
 
     return ClassType.specialize(
         type,
-        type.shared.typeParams.map((param) => getUnknownForTypeVar(param, tupleClassType)),
+        type.shared.typeParams.map((param) => getUnknownForTypeVar(param, tupleClassType, objectTypeForVarianceCheck)),
         /* isTypeArgExplicit */ false,
         /* includeSubclasses */ type.priv.includeSubclasses
     );
 }
 
-// Returns "Unknown" for simple TypeVars or the equivalent for a ParamSpec.
-export function getUnknownForTypeVar(typeVar: TypeVarType, tupleClassType?: ClassType): Type {
+/**
+ * Returns "Unknown" for simple TypeVars or the equivalent for a ParamSpec, or the widest allowed type if
+ * {@link objectTypeForVarianceCheck} is provided.
+ *
+ * ideally it would always do the variance check, but doing so interferes with bidirectional type inference
+ * in some edge cases. see https://github.com/microsoft/pyright/issues/5404#issuecomment-1639667443
+ *
+ * @param tupleClassType the builtin `tuple` type for special-casing tuples. needs to be passed so that this
+ * module doesn't depend on `typeEvaluator.ts`
+ * @param objectTypeForVarianceCheck the builtin `object` type to be returned if the type var is covariant.
+ * passing this parameter enables the variance check which allows it to return a better result than just "Unknown"
+ * in cases where the variance is known (ie. `object` or its bound if it's covariant, and `Never` if it's
+ * contravariant). needs to be passed so that this module doesn't depend on `typeEvaluator.ts`. note that
+ * `evaluator.inferVarianceForClass` needs to be called on {@link type} first if passing this parameter
+ */
+export function getUnknownForTypeVar(
+    typeVar: TypeVarType,
+    tupleClassType?: ClassType,
+    objectTypeForVarianceCheck?: Type
+): Type {
     if (isParamSpec(typeVar)) {
         return ParamSpecType.getUnknown();
     }
@@ -1116,7 +1149,17 @@ export function getUnknownForTypeVar(typeVar: TypeVarType, tupleClassType?: Clas
     if (isTypeVarTuple(typeVar) && tupleClassType) {
         return getUnknownForTypeVarTuple(tupleClassType);
     }
-
+    if (objectTypeForVarianceCheck) {
+        // if there are no usages of the TypeVar on the class and its variance isn't explicitly specified, it won't be
+        // known yet. https://github.com/DetachHead/basedpyright/issues/744
+        const variance = TypeVarType.getVariance(typeVar);
+        if (variance === Variance.Covariant) {
+            return typeVar.shared.boundType ?? objectTypeForVarianceCheck;
+        }
+        if (variance === Variance.Contravariant) {
+            return NeverType.createNever();
+        }
+    }
     return UnknownType.create();
 }
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1086,11 +1086,7 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
  * variance/bound for compatibility with less strictly typed code (cringe)
  */
 export const shouldUseVarianceForSpecialization = (type: Type) =>
-    !isAnyOrUnknown(type) &&
-    !isPartlyUnknown(type) &&
-    // TODO: this logic should probably be moved into `isAny`/`isUnknown` or something,
-    // to fix issues like https://github.com/DetachHead/basedpyright/issues/746
-    (type.category !== TypeCategory.TypeVar || !type.shared.isSynthesized);
+    (type.category !== TypeCategory.Class || type.shared.typeParams.length === 0);
 
 /**
  * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1082,6 +1082,17 @@ export function getTypeVarScopeIds(type: Type): TypeVarScopeId[] {
 }
 
 /**
+ * if the type we're narrowing is Any or Unknown, we don't want to specialize using the
+ * variance/bound for compatibility with less strictly typed code (cringe)
+ */
+export const shouldUseVarianceForSpecialization = (type: Type) =>
+    !isAnyOrUnknown(type) &&
+    !isPartlyUnknown(type) &&
+    // TODO: this logic should probably be moved into `isAny`/`isUnknown` or something,
+    // to fix issues like https://github.com/DetachHead/basedpyright/issues/746
+    (type.category !== TypeCategory.TypeVar || !type.shared.isSynthesized);
+
+/**
  * Specializes the class with "Unknown" type args (or the equivalent for ParamSpecs or TypeVarTuples), or its
  * widest possible type if its variance is known and {@link objectTypeForVarianceCheck} is provided (`object` if
  * the bound if covariant, `Never` if contravariant). see docstring on {@link getUnknownForTypeVar} for more info

--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -428,3 +428,17 @@ export function arrayEquals<T>(c1: T[], c2: T[], predicate: (e1: T, e2: T) => bo
 
     return c1.every((v, i) => predicate(v, c2[i]));
 }
+
+export const allCombinations = <T>(items: T[][]): T[][] => {
+    const [head, ...tail] = items;
+    if (!tail.length) {
+        return head.map((value) => [value]);
+    }
+    const result: T[][] = [];
+    for (const item1 of head) {
+        for (const item2 of allCombinations(tail)) {
+            result.push([item1, ...item2]);
+        }
+    }
+    return result;
+};

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -411,6 +411,7 @@ export interface DiagnosticRuleSet {
      * @see https://github.com/DetachHead/basedpyright/issues/603#issuecomment-2303297625
      */
     failOnWarnings: boolean;
+    improvedGenericNarrowing: boolean;
     reportUnreachable: DiagnosticLevel;
     reportAny: DiagnosticLevel;
     reportExplicitAny: DiagnosticLevel;
@@ -441,6 +442,7 @@ export function getBooleanDiagnosticRules(includeNonOverridable = false) {
         DiagnosticRule.enableExperimentalFeatures,
         DiagnosticRule.deprecateTypingAliases,
         DiagnosticRule.disableBytesTypePromotions,
+        DiagnosticRule.improvedGenericNarrowing,
     ];
 
     if (includeNonOverridable) {
@@ -673,6 +675,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
+        improvedGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -788,6 +791,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
+        improvedGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -903,6 +907,7 @@ export function getStandardDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
+        improvedGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -1017,6 +1022,7 @@ export const getRecommendedDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportShadowedImports: 'warning',
     reportImplicitOverride: 'warning',
     failOnWarnings: true,
+    improvedGenericNarrowing: true,
     reportUnreachable: 'warning',
     reportAny: 'warning',
     reportExplicitAny: 'warning',
@@ -1128,6 +1134,7 @@ export const getAllDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportShadowedImports: 'error',
     reportImplicitOverride: 'error',
     failOnWarnings: true,
+    improvedGenericNarrowing: true,
     reportUnreachable: 'error',
     reportAny: 'error',
     reportExplicitAny: 'error',
@@ -1240,6 +1247,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
+        improvedGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -411,7 +411,7 @@ export interface DiagnosticRuleSet {
      * @see https://github.com/DetachHead/basedpyright/issues/603#issuecomment-2303297625
      */
     failOnWarnings: boolean;
-    improvedGenericNarrowing: boolean;
+    strictGenericNarrowing: boolean;
     reportUnreachable: DiagnosticLevel;
     reportAny: DiagnosticLevel;
     reportExplicitAny: DiagnosticLevel;
@@ -442,7 +442,7 @@ export function getBooleanDiagnosticRules(includeNonOverridable = false) {
         DiagnosticRule.enableExperimentalFeatures,
         DiagnosticRule.deprecateTypingAliases,
         DiagnosticRule.disableBytesTypePromotions,
-        DiagnosticRule.improvedGenericNarrowing,
+        DiagnosticRule.strictGenericNarrowing,
     ];
 
     if (includeNonOverridable) {
@@ -675,7 +675,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
-        improvedGenericNarrowing: false,
+        strictGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -791,7 +791,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
-        improvedGenericNarrowing: false,
+        strictGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -907,7 +907,7 @@ export function getStandardDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
-        improvedGenericNarrowing: false,
+        strictGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',
@@ -1022,7 +1022,7 @@ export const getRecommendedDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportShadowedImports: 'warning',
     reportImplicitOverride: 'warning',
     failOnWarnings: true,
-    improvedGenericNarrowing: true,
+    strictGenericNarrowing: true,
     reportUnreachable: 'warning',
     reportAny: 'warning',
     reportExplicitAny: 'warning',
@@ -1134,7 +1134,7 @@ export const getAllDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportShadowedImports: 'error',
     reportImplicitOverride: 'error',
     failOnWarnings: true,
-    improvedGenericNarrowing: true,
+    strictGenericNarrowing: true,
     reportUnreachable: 'error',
     reportAny: 'error',
     reportExplicitAny: 'error',
@@ -1247,7 +1247,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportShadowedImports: 'none',
         reportImplicitOverride: 'none',
         failOnWarnings: false,
-        improvedGenericNarrowing: false,
+        strictGenericNarrowing: false,
         reportUnreachable: 'hint',
         reportAny: 'none',
         reportExplicitAny: 'none',

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -106,6 +106,7 @@ export enum DiagnosticRule {
 
     // basedpyright options:
     failOnWarnings = 'failOnWarnings',
+    improvedGenericNarrowing = 'improvedGenericNarrowing',
     reportUnreachable = 'reportUnreachable',
     reportAny = 'reportAny',
     reportExplicitAny = 'reportExplicitAny',

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -106,7 +106,7 @@ export enum DiagnosticRule {
 
     // basedpyright options:
     failOnWarnings = 'failOnWarnings',
-    improvedGenericNarrowing = 'improvedGenericNarrowing',
+    strictGenericNarrowing = 'strictGenericNarrowing',
     reportUnreachable = 'reportUnreachable',
     reportAny = 'reportAny',
     reportExplicitAny = 'reportExplicitAny',

--- a/packages/pyright-internal/src/tests/collectionUtils.test.ts
+++ b/packages/pyright-internal/src/tests/collectionUtils.test.ts
@@ -176,3 +176,59 @@ class D extends B {
         this.name = name;
     }
 }
+
+describe('allCombinations', () => {
+    test('2', () => {
+        assert.deepEqual(
+            utils.allCombinations([
+                ['int', 'str'],
+                ['dict', 'list'],
+            ]),
+            [
+                ['int', 'dict'],
+                ['int', 'list'],
+                ['str', 'dict'],
+                ['str', 'list'],
+            ]
+        );
+    });
+    test('3', () => {
+        assert.deepEqual(
+            utils.allCombinations([
+                ['int', 'str'],
+                ['dict', 'list'],
+                ['asdf', 'fdsa'],
+            ]),
+            [
+                ['int', 'dict', 'asdf'],
+                ['int', 'dict', 'fdsa'],
+                ['int', 'list', 'asdf'],
+                ['int', 'list', 'fdsa'],
+                ['str', 'dict', 'asdf'],
+                ['str', 'dict', 'fdsa'],
+                ['str', 'list', 'asdf'],
+                ['str', 'list', 'fdsa'],
+            ]
+        );
+    });
+    describe('varying lengths', () => {
+        test('2 and 1', () => {
+            assert.deepEqual(utils.allCombinations([['int', 'str'], ['dict', 'list'], ['asdf']]), [
+                ['int', 'dict', 'asdf'],
+                ['int', 'list', 'asdf'],
+                ['str', 'dict', 'asdf'],
+                ['str', 'list', 'asdf'],
+            ]);
+        });
+        test('3 and 2 and 1', () => {
+            assert.deepEqual(utils.allCombinations([['int', 'str', 'fdsa'], ['dict', 'list'], ['asdf']]), [
+                ['int', 'dict', 'asdf'],
+                ['int', 'list', 'asdf'],
+                ['str', 'dict', 'asdf'],
+                ['str', 'list', 'asdf'],
+                ['fdsa', 'dict', 'asdf'],
+                ['fdsa', 'list', 'asdf'],
+            ]);
+        });
+    });
+});

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance13.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance13.py
@@ -8,8 +8,8 @@ from typing import Any, Iterable, Sized
 
 def func1(v: Any) -> bool:
     if isinstance(v, Iterable):
-        reveal_type(v, expected_text="Iterable[Unknown]")
+        reveal_type(v, expected_text="Iterable[object]")
         if isinstance(v, Sized):
-            reveal_type(v, expected_text="<subclass of Iterable and Sized>")
+            reveal_type(v, expected_text="<subclass of Iterable[object] and Sized>")
             return True
     return False

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance13.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance13.py
@@ -8,8 +8,8 @@ from typing import Any, Iterable, Sized
 
 def func1(v: Any) -> bool:
     if isinstance(v, Iterable):
-        reveal_type(v, expected_text="Iterable[object]")
+        reveal_type(v, expected_text="Iterable[Unknown]")
         if isinstance(v, Sized):
-            reveal_type(v, expected_text="<subclass of Iterable[object] and Sized>")
+            reveal_type(v, expected_text="<subclass of Iterable and Sized>")
             return True
     return False

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance6.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance6.py
@@ -51,7 +51,7 @@ class ChildB1(ParentB[_T2]):
 
 def func4(var: ParentB[int]):
     if isinstance(var, ChildB1):
-        reveal_type(var, expected_text="ChildB1[int]")
+        reveal_type(var, expected_text="<subclass of ParentB[int] and ChildB1[float]>")
 
 
 def func5(var: ParentB[Any]):

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance6.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingIsinstance6.py
@@ -51,7 +51,7 @@ class ChildB1(ParentB[_T2]):
 
 def func4(var: ParentB[int]):
     if isinstance(var, ChildB1):
-        reveal_type(var, expected_text="<subclass of ParentB[int] and ChildB1[float]>")
+        reveal_type(var, expected_text="ChildB1[int]")
 
 
 def func5(var: ParentB[Any]):

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,4 +1,4 @@
-from typing import Any, Never, assert_type, Iterable
+from typing import Any, Never, assert_type, Iterable, Iterator, MutableMapping, Reversible
 
 
 class Covariant[T]:
@@ -66,3 +66,7 @@ class AnyOrUnknown:
     def partially_unknown(self, value=None):
         if isinstance(value, Iterable):
             assert_type(value, Iterable[Any])
+
+def foo[KT,VT](self: MutableMapping[KT, VT]) -> Iterator[KT]:
+    assert isinstance(self, Reversible) # fail
+    return reversed(self)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -48,7 +48,7 @@ class ContravariantWithBound[T: int | str]:
 
 
 class Invariant[T]:
-    """ make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    """make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
     def foo(self, other: object):
         if isinstance(other, Invariant):
             assert_type(other, Invariant[Any])  # Unknown
@@ -57,7 +57,7 @@ class Invariant[T]:
 
 
 class InvariantWithBound[T: float | bytes]:
-    """ make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    """make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
     def foo(self, other: object):
         if isinstance(other, Invariant):
             assert_type(other, Invariant[Any])  # Unknown

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,4 +1,4 @@
-from typing import Never, assert_type, Iterable
+from typing import Any, Never, assert_type, Iterable
 
 
 class Covariant[T]:
@@ -41,3 +41,18 @@ def foo(value: object):
     match value:
         case Iterable():
             assert_type(value, Iterable[object])
+
+class AnyOrUnknown:
+    """for backwards compatibility with badly typed code we keep the old functionality when narrowing `Any`/Unknown"""
+    def foo(self, value: Any):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+    def bar(self, value: Any):
+        match value:
+            case Iterable():
+                assert_type(value, Iterable[Any])
+
+    def partially_unknown(self, value=None):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,0 +1,43 @@
+from typing import Never, assert_type, Iterable
+
+
+class Covariant[T]:
+    def foo(self, other: object): 
+        if isinstance(other, Covariant):  
+            assert_type(other, Covariant[object])
+
+    def bar(self) -> T: ...
+
+class CovariantByDefault[T]:
+    """by default if there are no usages of a type var on a class, it's treated as covariant.
+    imo this should be an error. see https://github.com/DetachHead/basedpyright/issues/744"""
+    def foo(self, other: object): 
+        if isinstance(other, CovariantByDefault):  
+            assert_type(other, CovariantByDefault[object])
+
+class CovariantWithBound[T: int | str]:
+    def foo(self, other: object): 
+        if isinstance(other, CovariantWithBound):  
+            assert_type(other, CovariantWithBound[int | str])
+
+    def bar(self) -> T: ...
+
+class Contravariant[T]:
+    def foo(self, other: object): 
+        if isinstance(other, Contravariant):  
+            assert_type(other, Contravariant[Never])
+
+    def bar(self, other: T): ...
+
+class ContravariantWithBound[T: int | str]:
+    def foo(self, other: object): 
+        if isinstance(other, ContravariantWithBound):  
+            assert_type(other, ContravariantWithBound[Never])
+
+    def bar(self, other: T): ...
+
+
+def foo(value: object):
+    match value:
+        case Iterable():
+            assert_type(value, Iterable[object])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -2,39 +2,67 @@ from typing import Any, Never, assert_type, Iterable, Iterator, MutableMapping, 
 
 
 class Covariant[T]:
-    def foo(self, other: object): 
-        if isinstance(other, Covariant):  
+    def foo(self, other: object):
+        if isinstance(other, Covariant):
             assert_type(other, Covariant[object])
 
     def bar(self) -> T: ...
 
+
+class InheritCovariant[T](Covariant[T]):
+    def baz(self, other: Covariant[int]) -> None:
+        if isinstance(other, InheritCovariant):
+            assert_type(other, InheritCovariant[int])
+
+
 class CovariantByDefault[T]:
     """by default if there are no usages of a type var on a class, it's treated as covariant.
     imo this should be an error. see https://github.com/DetachHead/basedpyright/issues/744"""
-    def foo(self, other: object): 
-        if isinstance(other, CovariantByDefault):  
+    def foo(self, other: object):
+        if isinstance(other, CovariantByDefault):
             assert_type(other, CovariantByDefault[object])
 
+
 class CovariantWithBound[T: int | str]:
-    def foo(self, other: object): 
-        if isinstance(other, CovariantWithBound):  
+    def foo(self, other: object):
+        if isinstance(other, CovariantWithBound):
             assert_type(other, CovariantWithBound[int | str])
 
     def bar(self) -> T: ...
 
+
 class Contravariant[T]:
-    def foo(self, other: object): 
-        if isinstance(other, Contravariant):  
+    def foo(self, other: object):
+        if isinstance(other, Contravariant):
             assert_type(other, Contravariant[Never])
 
     def bar(self, other: T): ...
 
+
 class ContravariantWithBound[T: int | str]:
-    def foo(self, other: object): 
-        if isinstance(other, ContravariantWithBound):  
+    def foo(self, other: object):
+        if isinstance(other, ContravariantWithBound):
             assert_type(other, ContravariantWithBound[Never])
 
     def bar(self, other: T): ...
+
+
+class Invariant[T]:
+    """ make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    def foo(self, other: object):
+        if isinstance(other, Invariant):
+            assert_type(other, Invariant[Any])  # Unknown
+
+    def bar(self, other: T) -> T: ...
+
+
+class InvariantWithBound[T: float | bytes]:
+    """ make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    def foo(self, other: object):
+        if isinstance(other, Invariant):
+            assert_type(other, Invariant[Any])  # Unknown
+
+    def bar(self, other: T) -> T: ...
 
 
 def foo(value: object):
@@ -42,31 +70,32 @@ def foo(value: object):
         case Iterable():
             assert_type(value, Iterable[object])
 
+
 class AnyOrUnknown:
-    """for backwards compatibility with badly typed code we keep the old functionality when narrowing `Any`/Unknown"""
     def __init__(self, value):
         """arguments in `__init__` get turned into fake type vars if they're untyped, so we need to handle this case.
         see https://github.com/DetachHead/basedpyright/issues/746"""
         if isinstance(value, Iterable):
-            assert_type(value, Iterable[Any])
+            assert_type(value, Iterable[object])
 
     def any(self, value: Any):
         if isinstance(value, Iterable):
-            assert_type(value, Iterable[Any])
+            assert_type(value, Iterable[object])
 
     def match_case(self, value: Any):
         match value:
             case Iterable():
-                assert_type(value, Iterable[Any])
+                assert_type(value, Iterable[object])
 
     def unknown(self, value):
         if isinstance(value, Iterable):
-            assert_type(value, Iterable[Any])
+            assert_type(value, Iterable[object])
 
     def partially_unknown(self, value=None):
         if isinstance(value, Iterable):
-            assert_type(value, Iterable[Any])
+            assert_type(value, Iterable[object])
 
-def foo[KT,VT](self: MutableMapping[KT, VT]) -> Iterator[KT]:
-    assert isinstance(self, Reversible) # fail
+
+def goo[KT, VT](self: MutableMapping[KT, VT]) -> Iterator[KT]:
+    assert isinstance(self, Reversible)
     return reversed(self)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -99,3 +99,10 @@ class AnyOrUnknown:
 def goo[KT, VT](self: MutableMapping[KT, VT]) -> Iterator[KT]:
     assert isinstance(self, Reversible)
     return reversed(self)
+
+class Constraints[T: (int, str), U: (int, str), V: int]:
+    ...
+ 
+def _(value: object):
+    if isinstance(value, Constraints):
+        assert_type(value, Constraints[int, int, int] | Constraints[int, str, int] | Constraints[str, int, int] | Constraints[str, str, int])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,4 +1,4 @@
-from typing import Any, Never, assert_type, Iterable, Iterator, MutableMapping, Reversible
+from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible
 
 
 class Covariant[T]:
@@ -106,3 +106,13 @@ class Constraints[T: (int, str), U: (int, str), V: int]:
 def _(value: object):
     if isinstance(value, Constraints):
         assert_type(value, Constraints[int, int, int] | Constraints[int, str, int] | Constraints[str, int, int] | Constraints[str, str, int])
+
+@runtime_checkable
+class Foo[T: (int, str)](Protocol):
+    def asdf(self): ...
+
+def _(
+    value: str | Foo[str],
+):
+    if isinstance(value, Foo):
+        assert_type(value, Foo[str])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -44,14 +44,24 @@ def foo(value: object):
 
 class AnyOrUnknown:
     """for backwards compatibility with badly typed code we keep the old functionality when narrowing `Any`/Unknown"""
-    def foo(self, value: Any):
+    def __init__(self, value):
+        """arguments in `__init__` get turned into fake type vars if they're untyped, so we need to handle this case.
+        see https://github.com/DetachHead/basedpyright/issues/746"""
         if isinstance(value, Iterable):
             assert_type(value, Iterable[Any])
 
-    def bar(self, value: Any):
+    def any(self, value: Any):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+    def match_case(self, value: Any):
         match value:
             case Iterable():
                 assert_type(value, Iterable[Any])
+
+    def unknown(self, value):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
 
     def partially_unknown(self, value=None):
         if isinstance(value, Iterable):

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -1,4 +1,4 @@
-from typing import Any, assert_type, Iterable, Iterator, MutableMapping, Reversible
+from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible
 
 
 class Covariant[T]:
@@ -106,3 +106,13 @@ class Constraints[T: (int, str), U: (int, str), V: int]:
 def _(value: object):
     if isinstance(value, Constraints):
         assert_type(value, Constraints[Any, Any, Any])
+
+@runtime_checkable
+class Foo[T: (int, str)](Protocol):
+    def asdf(self): ...
+
+def _(
+    value: str | Foo[str],
+):
+    if isinstance(value, Foo):
+        assert_type(value, Foo[str])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -1,0 +1,108 @@
+from typing import Any, assert_type, Iterable, Iterator, MutableMapping, Reversible
+
+
+class Covariant[T]:
+    def foo(self, other: object):
+        if isinstance(other, Covariant):
+            assert_type(other, Covariant[Any])
+
+    def bar(self) -> T: ...
+
+
+class InheritCovariant[T](Covariant[T]):
+    def baz(self, other: Covariant[int]) -> None:
+        if isinstance(other, InheritCovariant):
+            assert_type(other, InheritCovariant[int])
+
+
+class CovariantByDefault[T]:
+    """by default if there are no usages of a type var on a class, it's treated as covariant.
+    imo this should be an error. see https://github.com/DetachHead/basedpyright/issues/744"""
+    def foo(self, other: object):
+        if isinstance(other, CovariantByDefault):
+            assert_type(other, CovariantByDefault[Any])
+
+
+class CovariantWithBound[T: int | str]:
+    def foo(self, other: object):
+        if isinstance(other, CovariantWithBound):
+            assert_type(other, CovariantWithBound[Any])
+
+    def bar(self) -> T: ...
+
+
+class Contravariant[T]:
+    def foo(self, other: object):
+        if isinstance(other, Contravariant):
+            assert_type(other, Contravariant[Any])
+
+    def bar(self, other: T): ...
+
+
+class ContravariantWithBound[T: int | str]:
+    def foo(self, other: object):
+        if isinstance(other, ContravariantWithBound):
+            assert_type(other, ContravariantWithBound[Any])
+
+    def bar(self, other: T): ...
+
+
+class Invariant[T]:
+    """make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    def foo(self, other: object):
+        if isinstance(other, Invariant):
+            assert_type(other, Invariant[Any])  # Unknown
+
+    def bar(self, other: T) -> T: ...
+
+
+class InvariantWithBound[T: float | bytes]:
+    """make sure invariant doesn't think it knows the type param - narrowing to invariant isn't safe """
+    def foo(self, other: object):
+        if isinstance(other, Invariant):
+            assert_type(other, Invariant[Any])  # Unknown
+
+    def bar(self, other: T) -> T: ...
+
+
+def foo(value: object):
+    match value:
+        case Iterable():
+            assert_type(value, Iterable[Any])
+
+
+class AnyOrUnknown:
+    def __init__(self, value):
+        """arguments in `__init__` get turned into fake type vars if they're untyped, so we need to handle this case.
+        see https://github.com/DetachHead/basedpyright/issues/746"""
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+    def any(self, value: Any):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+    def match_case(self, value: Any):
+        match value:
+            case Iterable():
+                assert_type(value, Iterable[Any])
+
+    def unknown(self, value):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+    def partially_unknown(self, value=None):
+        if isinstance(value, Iterable):
+            assert_type(value, Iterable[Any])
+
+
+def goo[KT, VT](self: MutableMapping[KT, VT]) -> Iterator[KT]:
+    assert isinstance(self, Reversible)
+    return reversed(self)
+
+class Constraints[T: (int, str), U: (int, str), V: int]:
+    ...
+ 
+def _(value: object):
+    if isinstance(value, Constraints):
+        assert_type(value, Constraints[Any, Any, Any])

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -434,7 +434,9 @@ test('TypeNarrowingIsinstance12', () => {
 });
 
 test('TypeNarrowingIsinstance13.py', () => {
-    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance13.py']);
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.improvedGenericNarrowing = true;
+    const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance13.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 0);
 });

--- a/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluator1.test.ts
@@ -435,7 +435,7 @@ test('TypeNarrowingIsinstance12', () => {
 
 test('TypeNarrowingIsinstance13.py', () => {
     const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.diagnosticRuleSet.improvedGenericNarrowing = true;
+    configOptions.diagnosticRuleSet.strictGenericNarrowing = true;
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['typeNarrowingIsinstance13.py'], configOptions);
 
     TestUtils.validateResults(analysisResults, 0);

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -122,7 +122,7 @@ describe('narrowing type vars using their bounds', () => {
     test('enabled', () => {
         const configOptions = new ConfigOptions(Uri.empty());
         configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
-        configOptions.diagnosticRuleSet.improvedGenericNarrowing = true;
+        configOptions.diagnosticRuleSet.strictGenericNarrowing = true;
         const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBounds.py'], configOptions);
         validateResultsButBased(analysisResults, {
             errors: [],
@@ -131,7 +131,7 @@ describe('narrowing type vars using their bounds', () => {
     test('disabled', () => {
         const configOptions = new ConfigOptions(Uri.empty());
         configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
-        configOptions.diagnosticRuleSet.improvedGenericNarrowing = false;
+        configOptions.diagnosticRuleSet.strictGenericNarrowing = false;
         const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBoundsDisabled.py'], configOptions);
         validateResultsButBased(analysisResults, {
             errors: [],

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -118,11 +118,23 @@ test('subscript context manager types on 3.8', () => {
     });
 });
 
-test('narrowing type vars using their bounds', () => {
-    const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
-    const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBounds.py'], configOptions);
-    validateResultsButBased(analysisResults, {
-        errors: [],
+describe('narrowing type vars using their bounds', () => {
+    test('enabled', () => {
+        const configOptions = new ConfigOptions(Uri.empty());
+        configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
+        configOptions.diagnosticRuleSet.improvedGenericNarrowing = true;
+        const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBounds.py'], configOptions);
+        validateResultsButBased(analysisResults, {
+            errors: [],
+        });
+    });
+    test('disabled', () => {
+        const configOptions = new ConfigOptions(Uri.empty());
+        configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
+        configOptions.diagnosticRuleSet.improvedGenericNarrowing = false;
+        const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBoundsDisabled.py'], configOptions);
+        validateResultsButBased(analysisResults, {
+            errors: [],
+        });
     });
 });

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -117,3 +117,12 @@ test('subscript context manager types on 3.8', () => {
         ],
     });
 });
+
+test('narrowing type vars using their bounds', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportUnusedParameter = 'none';
+    const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBounds.py'], configOptions);
+    validateResultsButBased(analysisResults, {
+        errors: [],
+    });
+});

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -100,7 +100,7 @@
       "title": "Treat typing-specific aliases to standard types as deprecated",
       "default": false
     },
-    "improvedGenericNarrowing": {
+    "strictGenericNarrowing": {
       "type": "boolean",
       "title": "Use generic bounds instead of `Any` when narrowing",
       "default": false
@@ -681,8 +681,8 @@
     "deprecateTypingAliases": {
       "$ref": "#/definitions/deprecateTypingAliases"
     },
-    "improvedGenericNarrowing": {
-      "$ref": "#/definitions/improvedGenericNarrowing"
+    "strictGenericNarrowing": {
+      "$ref": "#/definitions/strictGenericNarrowing"
     },
     "reportGeneralTypeIssues": {
       "$ref": "#/definitions/reportGeneralTypeIssues"
@@ -1035,8 +1035,8 @@
           "deprecateTypingAliases": {
             "$ref": "#/definitions/deprecateTypingAliases"
           },
-          "improvedGenericNarrowing": {
-            "$ref": "#/definitions/improvedGenericNarrowing"
+          "strictGenericNarrowing": {
+            "$ref": "#/definitions/strictGenericNarrowing"
           },
           "reportGeneralTypeIssues": {
             "$ref": "#/definitions/reportGeneralTypeIssues"

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -100,6 +100,11 @@
       "title": "Treat typing-specific aliases to standard types as deprecated",
       "default": false
     },
+    "improvedGenericNarrowing": {
+      "type": "boolean",
+      "title": "Use generic bounds instead of `Any` when narrowing",
+      "default": false
+    },
     "reportGeneralTypeIssues": {
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of general type issues",
@@ -676,6 +681,9 @@
     "deprecateTypingAliases": {
       "$ref": "#/definitions/deprecateTypingAliases"
     },
+    "improvedGenericNarrowing": {
+      "$ref": "#/definitions/improvedGenericNarrowing"
+    },
     "reportGeneralTypeIssues": {
       "$ref": "#/definitions/reportGeneralTypeIssues"
     },
@@ -1026,6 +1034,9 @@
           },
           "deprecateTypingAliases": {
             "$ref": "#/definitions/deprecateTypingAliases"
+          },
+          "improvedGenericNarrowing": {
+            "$ref": "#/definitions/improvedGenericNarrowing"
           },
           "reportGeneralTypeIssues": {
             "$ref": "#/definitions/reportGeneralTypeIssues"


### PR DESCRIPTION
- use a generic's bound when narrowing with `isinstance` if it's covariant, `Never` if it's contravariant
- creates a union of all possible combinations if it has constraints

fixes #674