### PR TITLE
Exasct matches only in code actions

### DIFF
--- a/packages/pyright-internal/src/common/collectionUtils.ts
+++ b/packages/pyright-internal/src/common/collectionUtils.ts
@@ -215,10 +215,10 @@ function stableSortIndices<T>(array: readonly T[], indices: number[], comparer: 
  */
 export const sorter = <T>(prev: T, next: T, comparator: (prev: T, next: T) => boolean) => {
     if (comparator(prev, next)) {
-        return 1;
+        return -1;
     }
     if (comparator(next, prev)) {
-        return -1;
+        return 1;
     }
     return 0;
 };

--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -133,23 +133,23 @@ export class CodeActionProvider {
             );
 
             const word = node.nodeType === ParseNodeType.Name ? node.d.value : undefined;
-            const completions = completer.getCompletions()?.items ?? [];
-            const sortedCompletions = completions
-                // code actions don't get sorted by sortText unlike completions, so we have to do it ourselves
+            const sortedCompletions = completer
+                .getCompletions()
+                ?.items.filter(
+                    (completion) =>
+                        // only show exact matches as code actions, which matches pylance's behavior. otherwise it's too noisy
+                        // because code actions don't get sorted like completions do. see https://github.com/DetachHead/basedpyright/issues/747
+                        completion.label === word
+                )
                 .sort((prev, next) =>
                     sorter(
                         prev,
                         next,
                         (prev, next) => (prev.sortText && next.sortText && prev.sortText < next.sortText) || false
                     )
-                )
-                // we also have to move exact matches to the top, something completions seems to also automatically
-                // do regardless of sortText
-                .sort((prev, next) =>
-                    sorter(prev, next, (prev, next) => (word && word === next.label && word !== prev.label) || false)
                 );
 
-            for (const suggestedImport of sortedCompletions) {
+            for (const suggestedImport of sortedCompletions ?? []) {
                 if (!suggestedImport.data) {
                     continue;
                 }


### PR DESCRIPTION
better solution to #587 

both pylance and typescript's code actions for import suggestions only show exact matches. i thought about it and decided that this behavior makes sense because unlike with completions, it's extremely unlikely that a user wants a non-exact match when invoking a code action on an undefined variable.

follow-up issue: #747 