### PR TITLE
Add link to pylance issues to pylance features page

### DIFF
--- a/docs/benefits-over-pyright/pylance-features.md
+++ b/docs/benefits-over-pyright/pylance-features.md
@@ -75,3 +75,7 @@ python -m docify path/to/typeshed/stdlib --if-needed --in-place
 when renaming a package or module, basedpyright will update all usages to the new name, just like pylance does:
 
 ![](https://github.com/user-attachments/assets/6207fe90-027a-4227-a1ed-d2c4406ad38c)
+
+## Pylance features missing from basedpyright
+
+See the [open issues](https://github.com/DetachHead/basedpyright/issues?q=is:issue+is:open+pylance+label:%22pylance+parity%22) related to feature parity with Pylance.


### PR DESCRIPTION
If you know about more existing missing features, it would be great to add them. This will help folks decide whether they should adopt basedpyright over pyright.

Jupyter notebook support is a blocker for us.