### PR TITLE
fix `typeCheckingMode` still defaulting to `"all"` in the language server when there's no config file

### DIFF
--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -97,7 +97,7 @@ export abstract class RealLanguageServer extends LanguageServerBase {
             disableLanguageServices: false,
             disableTaggedHints: false,
             disableOrganizeImports: false,
-            typeCheckingMode: 'all',
+            typeCheckingMode: 'recommended',
             diagnosticSeverityOverrides: {},
             logLevel: LogLevel.Info,
             autoImportCompletions: true,


### PR DESCRIPTION
fixes #785

really should start looking into #64, cuz this is so messy and error prone