### PR TITLE
Remove redundant bullet point

### DIFF
--- a/docs/benefits-over-pyright/pylance-features.md
+++ b/docs/benefits-over-pyright/pylance-features.md
@@ -20,7 +20,6 @@ basedpyright re-implements pylance's import suggestion code actions:
 
 basedpyright re-implements pylance's semantic highlighting along with some additional improvements:
 
--   variables marked as `Final` have the correct "read-only" colour
 -   supports [the new `type` keyword in python 3.12](https://peps.python.org/pep-0695/)
 -   `Final` variables are coloured as read-only
 


### PR DESCRIPTION
It was the same as the 3rd bullet. I deleted this one rather than the other one because the other one has a smoother phrasing.