### PR TITLE
add inlay hints for generics when instantiating classes

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -48,7 +48,7 @@ the following settings are exclusive to basedpyright
 
 ![](inlayHints.functionReturnTypes.png)
 
-**basedpyright.analysis.inlayHints.genericTypes** [boolean]: Whether to show inlay hints on inferred generic types. (currently only works on `Final` and `ClassVar`):
+**basedpyright.analysis.inlayHints.genericTypes** [boolean]: Whether to show inlay hints on inferred generic types. Defaults to `false`:
 
 ![](inlayHints.genericTypes.png)
 

--- a/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
@@ -171,7 +171,7 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
     }
 
     override visitCall(node: CallNode): boolean {
-        if (this._settings.callArgumentNames && this._checkInRange(node)) {
+        if (this._checkInRange(node)) {
             this._generateHintsForCallNode(node);
         }
         return super.visitCall(node);
@@ -247,6 +247,10 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
                     value: `[${returnType.priv.typeArgs.map((typeArg) => this._printType(typeArg)).join(', ')}]`,
                 });
             }
+        }
+
+        if (!this._settings.callArgumentNames) {
+            return;
         }
 
         // if it's an overload, figure out which one to use based on the arguments:

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1011,7 +1011,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 callArgumentNames: inlayHintSettings?.callArgumentNames ?? true,
                 functionReturnTypes: inlayHintSettings?.functionReturnTypes ?? true,
                 variableTypes: inlayHintSettings?.variableTypes ?? true,
-                genericTypes: inlayHintSettings?.genericTypes ?? true,
+                genericTypes: inlayHintSettings?.genericTypes ?? false,
             }).onInlayHints();
         }, token);
     }

--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -102,7 +102,12 @@ export abstract class RealLanguageServer extends LanguageServerBase {
             logLevel: LogLevel.Info,
             autoImportCompletions: true,
             functionSignatureDisplay: SignatureDisplayType.formatted,
-            inlayHints: { callArgumentNames: true, functionReturnTypes: true, variableTypes: true, genericTypes: true },
+            inlayHints: {
+                callArgumentNames: true,
+                functionReturnTypes: true,
+                variableTypes: true,
+                genericTypes: false,
+            },
         };
 
         try {

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Final
+from typing import ClassVar, Final, Unpack
 
 
 foo: Final = int()
@@ -15,4 +15,12 @@ class Foo[T]:
     def __init__(self, value: T) -> None:
         self.value = value
 
-_ = Foo("") 
+_ = Foo(True)
+
+_ = tuple((1,2,3))
+
+class Bar[U, *T]:
+    def __init__(self, asdf: U,*value: Unpack[T]) -> None:
+        pass
+
+_ = Bar([1], 1,2,"")

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
@@ -8,3 +8,11 @@ baz: Final[str] = ""
 class Foo:
     a: ClassVar = "asdf"
     b: ClassVar[str] = "asdf"
+
+_ = list([1])
+
+class Foo[T]:
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+_ = Foo("") 

--- a/packages/pyright-internal/src/tests/testUtils.ts
+++ b/packages/pyright-internal/src/tests/testUtils.ts
@@ -32,6 +32,7 @@ import { SemanticTokenItem, SemanticTokensWalker } from '../analyzer/semanticTok
 import { TypeInlayHintsItemType, TypeInlayHintsWalker } from '../analyzer/typeInlayHintsWalker';
 import { Range } from 'vscode-languageserver-types';
 import { ServiceProvider } from '../common/serviceProvider';
+import { InlayHintSettings } from '../common/languageServerInterface';
 
 // This is a bit gross, but it's necessary to allow the fallback typeshed
 // directory to be located when running within the jest environment. This
@@ -147,13 +148,17 @@ export const semanticTokenizeSampleFile = (fileName: string): SemanticTokenItem[
     return walker.items;
 };
 
-export const inlayHintSampleFile = (fileName: string, range?: Range): TypeInlayHintsItemType[] => {
+export const inlayHintSampleFile = (
+    fileName: string,
+    range?: Range,
+    settings: Partial<InlayHintSettings> = {}
+): TypeInlayHintsItemType[] => {
     const program = createProgram();
     const fileUri = UriEx.file(resolveSampleFilePath(path.join('inlay_hints', fileName)));
     program.setTrackedFiles([fileUri]);
     const walker = new TypeInlayHintsWalker(
         program,
-        { callArgumentNames: true, functionReturnTypes: true, variableTypes: true, genericTypes: true },
+        { callArgumentNames: true, functionReturnTypes: true, variableTypes: true, genericTypes: false, ...settings },
         fileUri,
         range
     );

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -101,6 +101,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 value: '[bool]',
             },
             {
+                inlayHintType: 'parameter',
+                position: 274,
+                value: 'value=',
+            },
+            {
                 inlayHintType: 'generic',
                 position: 290,
                 value: '[Literal[1, 2, 3], ...]',
@@ -109,6 +114,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 inlayHintType: 'generic',
                 position: 399,
                 value: '[list[int], int, int, str]',
+            },
+            {
+                inlayHintType: 'parameter',
+                position: 400,
+                value: 'asdf=',
             },
         ]);
     });

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -78,7 +78,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         ]);
     });
     test('generics', () => {
-        const result = inlayHintSampleFile('generics.py');
+        const result = inlayHintSampleFile('generics.py', undefined, { genericTypes: true });
         expect(result).toStrictEqual([
             {
                 inlayHintType: 'generic',
@@ -89,6 +89,16 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 inlayHintType: 'generic',
                 position: 118,
                 value: '[str]',
+            },
+            {
+                inlayHintType: 'generic',
+                position: 167,
+                value: '[int]',
+            },
+            {
+                inlayHintType: 'generic',
+                position: 265,
+                value: '[bool]',
             },
         ]);
     });

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -82,23 +82,33 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             {
                 inlayHintType: 'generic',
-                position: 47,
+                position: 55,
                 value: '[int]',
             },
             {
                 inlayHintType: 'generic',
-                position: 118,
+                position: 126,
                 value: '[str]',
             },
             {
                 inlayHintType: 'generic',
-                position: 167,
+                position: 175,
                 value: '[int]',
             },
             {
                 inlayHintType: 'generic',
-                position: 265,
+                position: 273,
                 value: '[bool]',
+            },
+            {
+                inlayHintType: 'generic',
+                position: 290,
+                value: '[Literal[1, 2, 3], ...]',
+            },
+            {
+                inlayHintType: 'generic',
+                position: 399,
+                value: '[list[int], int, int, str]',
             },
         ]);
     });

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1764,7 +1764,7 @@
                 },
                 "basedpyright.analysis.inlayHints.genericTypes": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to show inlay hints on inferred generic types.",
                     "scope": "resource"
                 }


### PR DESCRIPTION
- [x] maybe turn off this inlay hint type by default, because having inlay hints for both type annotations and generics often results in redundant information:
      ![image](https://github.com/user-attachments/assets/29bbb47b-c272-46ae-a180-ca96b698315c)
- [x] add tests
- [x] i think `tuple` needs to be special cased
- [x] update docs (currently it says only `Final` and `ClassVar` are supported)
- [ ] ~~other ways generics can be specialized eg. class method calls~~ (thats not a thing)