### PR TITLE
fix locale parsing on Linux

### DIFF
--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -158,7 +158,7 @@ export function getLocaleFromEnv(): string {
             const localeStringSplit = localeString.split('.');
             if (localeStringSplit.length > 0 && localeStringSplit[0]) {
                 // en_US -> en-us
-                const normalizedLocaleString = localeStringSplit[0].replace("_", "-").toLowerCase();
+                const normalizedLocaleString = localeStringSplit[0].replace('_', '-').toLowerCase();
                 return normalizedLocaleString || defaultLocale;
             }
         }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -154,10 +154,12 @@ export function getLocaleFromEnv(): string {
         // See if there is a language env variable.
         const localeString = env?.LC_ALL || env?.LC_MESSAGES || env?.LANG || env?.LANGUAGE;
         if (localeString) {
-            // This string may contain a local followed by an encoding (e.g. "en-us.UTF-8").
+            // This string may contain a local followed by an encoding (e.g. "en_US.UTF-8").
             const localeStringSplit = localeString.split('.');
             if (localeStringSplit.length > 0 && localeStringSplit[0]) {
-                return localeStringSplit[0] || defaultLocale;
+                // en_US -> en-us
+                const normalizedLocaleString = localeStringSplit[0].replace("_", "-").toLowerCase();
+                return normalizedLocaleString || defaultLocale;
             }
         }
     } catch {


### PR DESCRIPTION
Linux uses locale string `en_US.utf-8` instead `en-us.utf-8`. So I added a statement to convert between them correctly.