### PR TITLE
fix inlay hints appearing on `super()` calls

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
@@ -236,8 +236,11 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
         // inlay hints for generics
         if (
             this._settings.genericTypes &&
-            // where the type is not explicitly specified
-            node.d.leftExpr.nodeType !== ParseNodeType.Index &&
+            // where the type is not explicitly specified (theoretically we could show them on all node types that aren't
+            // `ParseNodeType.Index`, but we don't because it would probably look weird to show them on any other type of expression)
+            node.d.leftExpr.nodeType === ParseNodeType.Name &&
+            // don't show them on super calls because that's invalid.
+            node.d.leftExpr.d.value !== 'super' &&
             // only show them on classes, because the index syntax to specify generics isn't valid on functions
             isClass(callableType)
         ) {

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/generics.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Final, Unpack
+from typing import ClassVar, Final, Unpack, override
 
 
 foo: Final = int()
@@ -15,6 +15,8 @@ class Foo[T]:
     def __init__(self, value: T) -> None:
         self.value = value
 
+    def foo(self) -> None: ...
+
 _ = Foo(True)
 
 _ = tuple((1,2,3))
@@ -24,3 +26,8 @@ class Bar[U, *T]:
         pass
 
 _ = Bar([1], 1,2,"")
+
+class Baz(Foo[int]):
+    @override
+    def foo(self) -> None:
+        return super().foo()

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -82,42 +82,42 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             {
                 inlayHintType: 'generic',
-                position: 55,
+                position: 65,
                 value: '[int]',
             },
             {
                 inlayHintType: 'generic',
-                position: 126,
+                position: 136,
                 value: '[str]',
             },
             {
                 inlayHintType: 'generic',
-                position: 175,
+                position: 185,
                 value: '[int]',
             },
             {
                 inlayHintType: 'generic',
-                position: 273,
+                position: 315,
                 value: '[bool]',
             },
             {
                 inlayHintType: 'parameter',
-                position: 274,
+                position: 316,
                 value: 'value=',
             },
             {
                 inlayHintType: 'generic',
-                position: 290,
+                position: 332,
                 value: '[Literal[1, 2, 3], ...]',
             },
             {
                 inlayHintType: 'generic',
-                position: 399,
+                position: 441,
                 value: '[list[int], int, int, str]',
             },
             {
                 inlayHintType: 'parameter',
-                position: 400,
+                position: 442,
                 value: 'asdf=',
             },
         ]);


### PR DESCRIPTION
fixes #833