### PR TITLE
Update License Info with Well-known OSA MIT License Classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,16 @@ authors = [
     { name = "detachhead", email = "detachhead@users.noreply.github.com" },
 ]
 readme = "README.md"
-license = { text = "MIT" }
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 requires-python = ">=3.8"
 dependencies = [
     # required by the basedpyright cli & langserver wrapper scripts. only binaries are required (no cli)


### PR DESCRIPTION
I am currently unable to utilize ``basedpyright`` at my place of work because the (industry-standard) managed system we use to procure external code can not identify the license type.

This change replaces the current license property with the registered classifier for the MIT License, ensuring that it will be parsed properly by managed procurement tools like ours.

* Update license data in ``pyproject.toml``, replacing ``license`` property with ``classifiers``, containing the ``License :: OSI Approved :: MIT License`` classifier, and Python version classifiers from ``3.8``–``3.13``.