### PR TITLE
show `Never` instead of `NoReturn` when it's inferred as the return type of a function

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -19466,7 +19466,7 @@ export function createTypeEvaluator(
                         if (isAbstract || methodAlwaysRaisesNotImplemented(functionDecl)) {
                             inferredReturnType = UnknownType.create();
                         } else {
-                            inferredReturnType = NeverType.createNoReturn();
+                            inferredReturnType = NeverType.createNever();
                         }
                     } else {
                         const inferredReturnTypes: Type[] = [];

--- a/packages/pyright-internal/src/tests/samples/codeFlow4.py
+++ b/packages/pyright-internal/src/tests/samples/codeFlow4.py
@@ -130,7 +130,7 @@ def func12(val: A | B):
         raise Exception
 
 
-reveal_type(func12(A()), expected_text="NoReturn")
+reveal_type(func12(A()), expected_text="Never")
 
 
 def func13(val: int | float):

--- a/packages/pyright-internal/src/tests/samples/metaclass7.py
+++ b/packages/pyright-internal/src/tests/samples/metaclass7.py
@@ -19,7 +19,7 @@ class Class1(metaclass=MetaClass1):
 
 
 v1 = Class1()
-reveal_type(v1, expected_text="NoReturn")
+reveal_type(v1, expected_text="Never")
 
 
 class MetaClass2(type):


### PR DESCRIPTION
Issue  #357 