### PR TITLE
fix `strictGenericNarrowing` causing false positive `reportUnnecessaryIsInstance` errors when narrowing `Callable`

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1818,7 +1818,12 @@ function narrowTypeForInstance(
 
             if (
                 isClass(subtype) ||
-                (getFileInfo(errorNode).diagnosticRuleSet.strictGenericNarrowing && isFunction(subtype))
+                // when strictGenericNarrowing is enabled, we need to convert the Callable type to a Callable
+                // protocol to make sure it keeps the generics when narrowing, but this is only needed for
+                // isinstance checks because you can't specify generics to it
+                (!isTypeIsCheck &&
+                    getFileInfo(errorNode).diagnosticRuleSet.strictGenericNarrowing &&
+                    isFunction(subtype))
             ) {
                 if (isFunction(subtype)) {
                     subtype = synthesizeCallableProtocolFromFunctionType(evaluator, subtype, errorNode);

--- a/packages/pyright-internal/src/analyzer/typeGuards.ts
+++ b/packages/pyright-internal/src/analyzer/typeGuards.ts
@@ -1874,7 +1874,16 @@ const synthesizeCallableProtocolFromFunctionType = (
 ): ClassType => {
     //TODO: fix hover text. currently this causes narrowed `FunctionType`s to display like this:
     // "<subclass of Callable and staticmethod[..., object]>"
-    const callableType = ClassType.createInstantiable('Callable', '', '', Uri.empty(), 0, 0, undefined, undefined);
+    const callableType = ClassType.createInstantiable(
+        'Callable',
+        '',
+        '',
+        Uri.empty(),
+        ClassTypeFlags.ProtocolClass,
+        0,
+        undefined,
+        undefined
+    );
     callableType.shared.baseClasses.push(evaluator.getBuiltInType(errorNode, 'Protocol'));
     computeMroLinearization(callableType);
     const fields = ClassType.getSymbolTable(callableType);

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1089,9 +1089,7 @@ export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, strictGen
     }
     return allSubtypes(
         typeToNarrow,
-        (subtype) =>
-            (subtype.category !== TypeCategory.Class || subtype.shared.typeParams.length === 0) &&
-            (subtype.category !== TypeCategory.Function || !subtype.priv.isCallableWithTypeArgs)
+        (subtype) => subtype.category !== TypeCategory.Class || subtype.shared.typeParams.length === 0
     );
 };
 

--- a/packages/pyright-internal/src/analyzer/typeUtils.ts
+++ b/packages/pyright-internal/src/analyzer/typeUtils.ts
@@ -1090,9 +1090,8 @@ export const shouldUseVarianceForSpecialization = (typeToNarrow: Type, strictGen
     return allSubtypes(
         typeToNarrow,
         (subtype) =>
-            subtype.category !== TypeCategory.Class ||
-            // !ClassType.isSameGenericClass(subtype, narrowToType) ||
-            subtype.shared.typeParams.length === 0
+            (subtype.category !== TypeCategory.Class || subtype.shared.typeParams.length === 0) &&
+            (subtype.category !== TypeCategory.Function || !subtype.priv.isCallableWithTypeArgs)
     );
 };
 

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,5 +1,5 @@
 from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
-
+from types import FunctionType
 
 class Covariant[T]:
     def foo(self, other: object):
@@ -131,3 +131,7 @@ class CallableProtocol[**P, T](Protocol):
 def _(f: CallableProtocol[[], None]):
     if isinstance(f, staticmethod):
         assert_type(f, staticmethod[[], None])
+
+def _(f: Callable[[int], str]):
+    if isinstance(f, FunctionType):
+        assert_type(f, FunctionType)

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -117,11 +117,12 @@ def _(
     if isinstance(value, Foo):
         assert_type(value, Foo[str])
 
-def _(f: Callable[[], None]):
+def _(f: Callable[[int], str]):
     if isinstance(f, staticmethod):
-        # narrowing Callable this way doesn't work so we use the old method.
-        # see https://github.com/DetachHead/basedpyright/issues/905
-        assert_type(f, staticmethod[..., Any])
+        # can't use assert_type on the function itself, see TODO in synthesizeCallableProtocolFromFunctionType
+        assert_type(f(1), str)
+        assert_type(f.__call__, Callable[[int], str])
+        reveal_type(f)
 
 class CallableProtocol[**P, T](Protocol):
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T: ...

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,4 +1,4 @@
-from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
+from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable, TypeIs
 from types import FunctionType
 
 class Covariant[T]:
@@ -135,3 +135,9 @@ def _(f: CallableProtocol[[], None]):
 def _(f: Callable[[int], str]):
     if isinstance(f, FunctionType):
         assert_type(f, FunctionType)
+
+def takes_arg(value: object) -> TypeIs[Callable[[int], None]]: ...
+
+def _(value: Callable[[], None] | Callable[[int], None]):
+    if takes_arg(value):
+        assert_type(value, Callable[[int], None])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBounds.py
@@ -1,4 +1,4 @@
-from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible
+from typing import Any, Never, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
 
 
 class Covariant[T]:
@@ -116,3 +116,17 @@ def _(
 ):
     if isinstance(value, Foo):
         assert_type(value, Foo[str])
+
+def _(f: Callable[[], None]):
+    if isinstance(f, staticmethod):
+        # narrowing Callable this way doesn't work so we use the old method.
+        # see https://github.com/DetachHead/basedpyright/issues/905
+        assert_type(f, staticmethod[..., Any])
+
+class CallableProtocol[**P, T](Protocol):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+def _(f: CallableProtocol[[], None]):
+    if isinstance(f, staticmethod):
+        assert_type(f, staticmethod[[], None])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -1,4 +1,4 @@
-from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible
+from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
 
 
 class Covariant[T]:
@@ -116,3 +116,17 @@ def _(
 ):
     if isinstance(value, Foo):
         assert_type(value, Foo[str])
+
+def _(f: Callable[[], None]):
+    if isinstance(f, staticmethod):
+        # narrowing Callable this way doesn't work so we use the old method.
+        # see https://github.com/DetachHead/basedpyright/issues/905
+        assert_type(f, staticmethod[..., Any])
+
+class CallableProtocol[**P, T](Protocol):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+
+def _(f: CallableProtocol[[], None]):
+    if isinstance(f, staticmethod):
+        assert_type(f, staticmethod[[], None])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -1,4 +1,4 @@
-from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
+from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable, TypeIs
 from types import FunctionType
 
 
@@ -133,3 +133,9 @@ def _(f: CallableProtocol[[], None]):
 def _(f: Callable[[int], str]):
     if isinstance(f, FunctionType):
         assert_type(f, FunctionType)
+        
+def takes_arg(value: object) -> TypeIs[Callable[[int], None]]: ...
+
+def _(value: Callable[[], None] | Callable[[int], None]):
+    if takes_arg(value):
+        assert_type(value, Callable[[int], None])

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -119,8 +119,6 @@ def _(
 
 def _(f: Callable[[], None]):
     if isinstance(f, staticmethod):
-        # narrowing Callable this way doesn't work so we use the old method.
-        # see https://github.com/DetachHead/basedpyright/issues/905
         assert_type(f, staticmethod[..., Any])
 
 class CallableProtocol[**P, T](Protocol):

--- a/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
+++ b/packages/pyright-internal/src/tests/samples/typeNarrowingUsingBoundsDisabled.py
@@ -1,4 +1,5 @@
 from typing import Any, assert_type, runtime_checkable, Protocol, Iterable, Iterator, MutableMapping, Reversible, Callable
+from types import FunctionType
 
 
 class Covariant[T]:
@@ -128,3 +129,7 @@ class CallableProtocol[**P, T](Protocol):
 def _(f: CallableProtocol[[], None]):
     if isinstance(f, staticmethod):
         assert_type(f, staticmethod[[], None])
+
+def _(f: Callable[[int], str]):
+    if isinstance(f, FunctionType):
+        assert_type(f, FunctionType)

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -126,6 +126,7 @@ describe('narrowing type vars using their bounds', () => {
         const analysisResults = typeAnalyzeSampleFiles(['typeNarrowingUsingBounds.py'], configOptions);
         validateResultsButBased(analysisResults, {
             errors: [],
+            infos: [{ line: 124, message: 'Type of "f" is "<subclass of Callable and staticmethod[..., object]>"' }],
         });
     });
     test('disabled', () => {


### PR DESCRIPTION
- fixes #905
- fixes #452