### PR TITLE
fix `reportUnsafeMultipleInheritance` false positive in diamond inheritance scenarios, which is safe due to how MRO works

### DIFF
--- a/packages/pyright-internal/src/tests/samples/multipleInheritance.py
+++ b/packages/pyright-internal/src/tests/samples/multipleInheritance.py
@@ -58,3 +58,15 @@ class U(A, C): # error
 @dataclass(init=False)
 class V(A, C): # no error
     ...
+
+class Up:
+    def __init__(self): ...
+
+
+class Left(Up): ...
+
+
+class Right(Up): ...
+
+
+class Down(Left, Right): ...  # no error


### PR DESCRIPTION
fixes #657 