### PR TITLE
fix paramspecs being printed as `Callable` types in inlay hints

### DIFF
--- a/packages/pyright-internal/src/analyzer/typePrinter.ts
+++ b/packages/pyright-internal/src/analyzer/typePrinter.ts
@@ -845,6 +845,7 @@ function printFunctionType(
             );
         }
 
+        let result: string;
         if (isPositionalParamsOnly) {
             const paramTypes: string[] = [];
 
@@ -870,20 +871,19 @@ function printFunctionType(
 
             if (paramSpec) {
                 if (paramTypes.length > 0) {
-                    return `Callable[Concatenate[${paramTypes.join(', ')}, ${
-                        paramSpec.shared.name
-                    }], ${returnTypeString}]`;
+                    result = `Concatenate[${paramTypes.join(', ')}, ${paramSpec.shared.name}]`;
+                } else {
+                    result = paramSpec.shared.name;
                 }
-
-                return `Callable[${paramSpec.shared.name}, ${returnTypeString}]`;
+            } else {
+                result = `[${paramTypes.join(', ')}]`;
             }
-
-            return `Callable[[${paramTypes.join(', ')}], ${returnTypeString}]`;
         } else {
             // We can't represent this type using a Callable so default to
             // a "catch all" Callable.
-            return `Callable[..., ${returnTypeString}]`;
+            result = '...';
         }
+        return FunctionType.isParamSpecValue(type) ? result : `Callable[${result}, ${returnTypeString}]`;
     } else {
         const parts = printFunctionPartsInternal(
             type,

--- a/packages/pyright-internal/src/tests/typePrinter.test.ts
+++ b/packages/pyright-internal/src/tests/typePrinter.test.ts
@@ -186,3 +186,26 @@ test('FunctionTypes', () => {
     assert.strictEqual(printType(funcTypeD, PrintTypeFlags.None, returnTypeCallback), '(**P) -> Any');
     assert.strictEqual(printType(funcTypeD, PrintTypeFlags.PythonSyntax, returnTypeCallback), 'Callable[P, Any]');
 });
+
+describe('ParamSpec', () => {
+    test('positional only', () => {
+        const paramSpec = FunctionType.createSynthesizedInstance('', FunctionTypeFlags.ParamSpecValue);
+        for (const name of ['a', 'b']) {
+            FunctionType.addParam(
+                paramSpec,
+                FunctionParam.create(ParamCategory.Simple, AnyType.create(), FunctionParamFlags.TypeDeclared, name)
+            );
+        }
+        FunctionType.addPositionOnlyParamSeparator(paramSpec);
+        assert.strictEqual(printType(paramSpec, PrintTypeFlags.PythonSyntax, returnTypeCallback), '[Any, Any]');
+    });
+    test('keyword only', () => {
+        const paramSpec = FunctionType.createSynthesizedInstance('', FunctionTypeFlags.ParamSpecValue);
+        FunctionType.addKeywordOnlyParamSeparator(paramSpec);
+        FunctionType.addParam(
+            paramSpec,
+            FunctionParam.create(ParamCategory.Simple, AnyType.create(), FunctionParamFlags.TypeDeclared, 'a')
+        );
+        assert.strictEqual(printType(paramSpec, PrintTypeFlags.PythonSyntax, returnTypeCallback), '...');
+    });
+});


### PR DESCRIPTION
fixes #934