### PR TITLE
docs: add missing `settings` table

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -95,7 +95,7 @@ the basedpyright language server settings can be configured using a workspace or
 
 ### neovim
 
-the language server can be configured in your neovim settings:
+The language server can be configured in your neovim settings:
 
 ```lua
 require("lspconfig").basedpyright.setup {

--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -99,9 +99,11 @@ the language server can be configured in your neovim settings:
 
 ```lua
 require("lspconfig").basedpyright.setup {
-  basedpyright = {
-    analysis = {
-      diagnosticMode = "openFilesOnly",
+  settings = {
+    basedpyright = {
+      analysis = {
+        diagnosticMode = "openFilesOnly",
+        }
     }
   }
 }


### PR DESCRIPTION
The docs showing how to setup basedpyright with nvim-lspconfig have a small issue. As per [the official docs](https://github.com/neovim/nvim-lspconfig/blob/41e249e7787ab2ca16160bbc4bb4cfca28542995/doc/lspconfig.txt#L99-L122), the lsp-specific config should be within a `settings` key.