### PR TITLE
officially support installing basedpyright via npm

### DIFF
--- a/docs/benefits-over-pyright/pypi-package-vscode-pinning.md
+++ b/docs/benefits-over-pyright/pypi-package-vscode-pinning.md
@@ -4,7 +4,11 @@
 
 pyright is only published as an npm package, which requires you to install nodejs. [the version on pypi](https://pypi.org/project/pyright/) is just an unofficial wrapper that installs node and the npm package the first time you invoke the cli, [which is quite flaky](https://github.com/RobertCraigie/pyright-python/issues/231).
 
-python developers should not be expected to have to install nodejs in order to typecheck their python code. it should just be a regular pypi package like mypy, ruff, and pretty much all other python tooling. this is why basedpyright is [officially published on pypi](https://pypi.org/project/basedpyright/), which comes bundled with the npm package.
+python developers should not be expected to install nodejs in order to typecheck their python code. although pyright itself is written in typescript and therefore depends on nodejs, it's an implementation detail that should be of no concern to the user. a command-line tool intended for python developers should not have to be installed and managed by a package manager for a completely different language.
+
+this is why basedpyright is [officially published on pypi](https://pypi.org/project/basedpyright/), which comes bundled with the npm package using [nodejs-wheel](https://github.com/njzjz/nodejs-wheel).
+
+see [the installation instructions](../installation/command-line-and-language-server.md#pypi-package-recommended) for more information.
 
 ## ability to pin the version used by vscode
 

--- a/docs/installation/command-line-and-language-server.md
+++ b/docs/installation/command-line-and-language-server.md
@@ -2,7 +2,7 @@
 
 ## pypi package (recommended)
 
-unlike pyright, the basedpyright CLI & LSP are available as a [pypi package](https://pypi.org/project/basedpyright/) instead of an npm package.
+unlike pyright, the basedpyright CLI and language server are available as a [pypi package](https://pypi.org/project/basedpyright/).
 
 this makes it far more convenient for python developers to use, since there's no need to install any additional tools. just install it normally via your package manager of choice:
 
@@ -51,6 +51,16 @@ the basedpyright CLI & language server is also available outside of pypi:
 === "nixOS"
 
      [see here](https://search.nixos.org/packages?channel=unstable&show=basedpyright)
+
+=== "npm"
+
+     ```
+     npm install basedpyright
+     ```
+
+     note that we recommend installing basedpyright via pypi instead - [see here for more information](https://www.npmjs.com/package/basedpyright?activeTab=readme).
+
+     the basedpyright npm package is intended for users who are unable to use the pypi package for some reason. for example if you're using an operating system not [supported by nodejs-wheel](https://github.com/njzjz/nodejs-wheel?tab=readme-ov-file#available-builds) or a version of python older than 3.8.
 
 ## usage
 

--- a/packages/pyright/README.md
+++ b/packages/pyright/README.md
@@ -4,8 +4,8 @@ basedpyright is a pyright fork with various type checking improvements, improved
 
 **[full documentation](https://docs.basedpyright.com)**
 
-## ⚠ warning
+## installation
 
-this npm package is only really intended for internal use. the recommended way to install basedpyright is [from pypi](https://pypi.org/project/basedpyright/). see [the docs for more information](https://docs.basedpyright.com/latest/benefits-over-pyright/pypi-package-vscode-pinning/).
+it's recommended to install basedpyright [via pypi](https://docs.basedpyright.com/latest/installation/command-line-and-language-server/#pypi-package-recommended) rather than npm. [see here](https://docs.basedpyright.com/latest/benefits-over-pyright/pypi-package-vscode-pinning/#ability-to-pin-the-version-used-by-vscode) for more information.
 
-if you have a use case for the npm package, feel free to [raise an issue](https://github.com/DetachHead/basedpyright/issues).
+the basedpyright npm package is intended for users who are unable to use the pypi package for some reason, for example if you're using an operating system not [supported by nodejs-wheel](https://github.com/njzjz/nodejs-wheel?tab=readme-ov-file#available-builds) or a version of python older than 3.8.

--- a/packages/pyright/package.json
+++ b/packages/pyright/package.json
@@ -40,6 +40,8 @@
     ],
     "main": "index.js",
     "bin": {
+        "basedpyright": "index.js",
+        "basedpyright-langserver": "langserver.index.js",
         "pyright": "index.js",
         "pyright-langserver": "langserver.index.js"
     }


### PR DESCRIPTION
- fixes #586
- fixes #549
- fixes #520