### PR TITLE
fix `File or directory "/<default workspace root>" does not exist` error being reported as a language server notification

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1441,9 +1441,13 @@ export class AnalyzerService {
                 }
 
                 if (!foundFileSpec) {
-                    (this._console as ConsoleInterface).error(
-                        `File or directory "${includeSpec.wildcardRoot.toUserVisibleString()}" does not exist.`
-                    );
+                    const path = includeSpec.wildcardRoot.toUserVisibleString();
+                    const message = `File or directory "${path}" does not exist.`;
+                    if (path.includes(Uri.DefaultWorkspaceRootComponent)) {
+                        this._console.warn(message);
+                    } else {
+                        this._console.error(message);
+                    }
                 }
             }
         });


### PR DESCRIPTION
fixes #965