### PR TITLE
Implemented allowedUntypedLibraries config

### DIFF
--- a/docs/benefits-over-pyright/better-defaults.md
+++ b/docs/benefits-over-pyright/better-defaults.md
@@ -8,6 +8,7 @@ used to be `"basic"`, but now defaults to `"recommended"`, which enables all dia
 
 -   less severe diagnostic rules are reported as warnings instead of errors. this reduces [alarm fatigue](https://en.wikipedia.org/wiki/Alarm_fatigue) while still ensuring that the user is made aware of all potentential issues that basedpyright can detect. `failOnWarnings` is also enabled by default in this mode, which causes the CLI to exit with a non-zero exit code if any warnings are detected. you disable this behavior by setting `failOnWarnings` to `false`.
 -   we support [baselining](./baseline.md) to allow for easy adoption of more strict rules in existing codebases.
+-   we've added a new setting, [`allowedUntypedLibraries`](../configuration/config-files.md#allowedUntypedLibraries) which allows you to turn off rules about unknown types on a per-module basis, which can be useful when working with third party packages that aren't properly typed.
 
 ## `pythonPlatform`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,8 @@ The following settings allow more fine grained control over the **typeCheckingMo
 
 - <a name="reportShadowedImports"></a> **reportShadowedImports** [boolean or string, optional]: Generate or suppress diagnostics for files that are overriding a module in the stdlib.
 
+- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules **reportUnknownParameterType**, **reportUnknownArgumentType**, **reportUnknownMemberType**, and **reportMissingTypeStubs**. The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
+
 ### basedpyright exclusive settings
 
 - <a name="reportUnreachable"></a> **reportUnreachable** [boolean or string, optional]: Generate or suppress diagnostics for unreachable code. [more info](../benefits-over-pyright/new-diagnostic-rules.md#reportunreachable)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,8 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="failOnWarnings"></a> **failOnWarnings** [boolean]: Whether to exit with a non-zero exit code in the CLI if any `"warning"` diagnostics are reported. Has no effect on the language server. This is equivalent to the `--warnings` CLI argument.
 
+- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules **reportUnknownParameterType**, **reportUnknownArgumentType**, **reportUnknownMemberType**, and **reportMissingTypeStubs**. The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
+
 ## Type Evaluation Settings
 
 The following settings determine how different types should be evaluated.
@@ -266,8 +268,6 @@ The following settings allow more fine grained control over the **typeCheckingMo
 - <a name="reportImplicitOverride"></a> **reportImplicitOverride** [boolean or string, optional]: Generate or suppress diagnostics for overridden methods in a class that are missing an explicit `@override` decorator.
 
 - <a name="reportShadowedImports"></a> **reportShadowedImports** [boolean or string, optional]: Generate or suppress diagnostics for files that are overriding a module in the stdlib.
-
-- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules **reportUnknownParameterType**, **reportUnknownArgumentType**, **reportUnknownMemberType**, and **reportMissingTypeStubs**. The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
 ### basedpyright exclusive settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="failOnWarnings"></a> **failOnWarnings** [boolean]: Whether to exit with a non-zero exit code in the CLI if any `"warning"` diagnostics are reported. Has no effect on the language server. This is equivalent to the `--warnings` CLI argument.
 
-- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownParameterType`](#reportUnknownParameterType), [`reportUnknownArgumentType`](#reportUnknownArgumentType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
+- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownVariableType`](#reportUnknownVariableType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
 ## Type Evaluation Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="failOnWarnings"></a> **failOnWarnings** [boolean]: Whether to exit with a non-zero exit code in the CLI if any `"warning"` diagnostics are reported. Has no effect on the language server. This is equivalent to the `--warnings` CLI argument.
 
-- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules **reportUnknownParameterType**, **reportUnknownArgumentType**, **reportUnknownMemberType**, and **reportMissingTypeStubs**. The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
+- <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownParameterType`](#reportUnknownParameterType), [`reportUnknownArgumentType`](#reportUnknownArgumentType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
 ## Type Evaluation Settings
 

--- a/packages/pyright-internal/src/analyzer/binder.ts
+++ b/packages/pyright-internal/src/analyzer/binder.ts
@@ -403,10 +403,12 @@ export class Binder extends ParseTreeWalker {
         }
 
         // A source file was found, but the type stub was missing.
+        // If the module is allowed as an untyped library, we don't need the stub
         if (
             !importResult.isStubFile &&
             importResult.importType === ImportType.ThirdParty &&
-            !importResult.pyTypedInfo
+            !importResult.pyTypedInfo &&
+            !this._ignoreUntypedModule(importResult.importName)
         ) {
             const diagnostic = this._addDiagnostic(
                 DiagnosticRule.reportMissingTypeStubs,
@@ -4330,6 +4332,10 @@ export class Binder extends ParseTreeWalker {
 
     private _addSyntaxError(message: string, textRange: TextRange) {
         return this._fileInfo.diagnosticSink.addDiagnosticWithTextRange('error', message, textRange);
+    }
+
+    private _ignoreUntypedModule(module: string) {
+        return this._fileInfo.diagnosticRuleSet.allowedUntypedLibraries.some(x => (module + ".").startsWith(x + "."));
     }
 }
 

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -219,5 +219,5 @@ function addPathIfUnique(pathList: Uri[], pathToAdd: Uri) {
 }
 
 export function moduleIsInList(modules: string[], module: string) {
-    return modules.some(x => (module + ".").startsWith(x + "."));
+    return modules.some((x) => (module + '.').startsWith(x + '.'));
 }

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -219,5 +219,5 @@ function addPathIfUnique(pathList: Uri[], pathToAdd: Uri) {
 }
 
 export function moduleIsInList(modules: string[], module: string) {
-    return modules.some((x) => (module + '.').startsWith(x + '.'));
+    return modules.some((modulePart) => (module + '.').startsWith(modulePart + '.'));
 }

--- a/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
+++ b/packages/pyright-internal/src/analyzer/pythonPathUtils.ts
@@ -217,3 +217,7 @@ function addPathIfUnique(pathList: Uri[], pathToAdd: Uri) {
 
     return false;
 }
+
+export function moduleIsInList(modules: string[], module: string) {
+    return modules.some(x => (module + ".").startsWith(x + "."));
+}

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -373,6 +373,7 @@ import {
     validateTypeVarDefault,
 } from './typeUtils';
 import { Commands } from '../commands/commands';
+import { moduleIsInList } from './pythonPathUtils';
 
 interface GetTypeArgsOptions {
     isAnnotatedClass?: boolean;
@@ -15114,10 +15115,6 @@ export function createTypeEvaluator(
         return { type, isIncomplete, typeErrors };
     }
 
-    function _ignoreUntypedModule(ruleset: DiagnosticRuleSet, module: string) {
-        return ruleset.allowedUntypedLibraries.some(x => (module + ".").startsWith(x + "."));
-    }
-
     function reportPossibleUnknownAssignment(
         ruleset: DiagnosticRuleSet,
         rule: DiagnosticRule,
@@ -15134,7 +15131,7 @@ export function createTypeEvaluator(
         // Or if the object is in an untyped library that was explicitly mentioned.
         if (type.shared && "moduleName" in type.shared) {
             const moduleName = type.shared.moduleName;
-            if (_ignoreUntypedModule(ruleset, moduleName)) {
+            if (moduleIsInList(ruleset.allowedUntypedLibraries, moduleName)) {
                 return;
             }
         }

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15114,6 +15114,10 @@ export function createTypeEvaluator(
         return { type, isIncomplete, typeErrors };
     }
 
+    function _ignoreUntypedModule(ruleset: DiagnosticRuleSet, module: string) {
+        return ruleset.allowedUntypedLibraries.some(x => (module + ".").startsWith(x + "."));
+    }
+
     function reportPossibleUnknownAssignment(
         ruleset: DiagnosticRuleSet,
         rule: DiagnosticRule,
@@ -15125,6 +15129,14 @@ export function createTypeEvaluator(
         // Don't bother if the features are disabled.
         if (ruleset[rule] === 'none' && ruleset.reportAny === 'none') {
             return;
+        }
+
+        // Or if the object is in an untyped library that was explicitly mentioned.
+        if (type.shared && "moduleName" in type.shared) {
+            const moduleName = type.shared.moduleName;
+            if (_ignoreUntypedModule(ruleset, moduleName)) {
+                return;
+            }
         }
 
         const nameValue = target.d.value;

--- a/packages/pyright-internal/src/analyzer/typeEvaluator.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluator.ts
@@ -15129,7 +15129,7 @@ export function createTypeEvaluator(
         }
 
         // Or if the object is in an untyped library that was explicitly mentioned.
-        if (type.shared && "moduleName" in type.shared) {
+        if (type.shared && 'moduleName' in type.shared) {
             const moduleName = type.shared.moduleName;
             if (moduleIsInList(ruleset.allowedUntypedLibraries, moduleName)) {
                 return;

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -423,6 +423,7 @@ export interface DiagnosticRuleSet {
     reportUnusedParameter: DiagnosticLevel;
     reportImplicitAbstractClass: DiagnosticLevel;
     reportUnannotatedClassAttribute: DiagnosticLevel;
+    allowedUntypedLibraries: string[];
 }
 
 export function cloneDiagnosticRuleSet(diagSettings: DiagnosticRuleSet): DiagnosticRuleSet {
@@ -687,6 +688,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedParameter: 'hint',
         reportImplicitAbstractClass: 'none',
         reportUnannotatedClassAttribute: 'none',
+        allowedUntypedLibraries: [],
     };
 
     return diagSettings;
@@ -803,6 +805,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedParameter: 'hint',
         reportImplicitAbstractClass: 'none',
         reportUnannotatedClassAttribute: 'none',
+        allowedUntypedLibraries: [],
     };
 
     return diagSettings;
@@ -919,6 +922,7 @@ export function getStandardDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedParameter: 'hint',
         reportImplicitAbstractClass: 'none',
         reportUnannotatedClassAttribute: 'none',
+        allowedUntypedLibraries: [],
     };
 
     return diagSettings;
@@ -1034,6 +1038,7 @@ export const getRecommendedDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportUnusedParameter: 'warning',
     reportImplicitAbstractClass: 'warning',
     reportUnannotatedClassAttribute: 'warning',
+    allowedUntypedLibraries: [],
 });
 
 export const getAllDiagnosticRuleSet = (): DiagnosticRuleSet => ({
@@ -1146,6 +1151,7 @@ export const getAllDiagnosticRuleSet = (): DiagnosticRuleSet => ({
     reportUnusedParameter: 'error',
     reportImplicitAbstractClass: 'error',
     reportUnannotatedClassAttribute: 'error',
+    allowedUntypedLibraries: [],
 });
 
 export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
@@ -1259,6 +1265,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedParameter: 'hint',
         reportImplicitAbstractClass: 'none',
         reportUnannotatedClassAttribute: 'none',
+        allowedUntypedLibraries: [],
     };
 
     return diagSettings;
@@ -1601,6 +1608,25 @@ export class ConfigOptions {
                 console
             );
         });
+
+        // Read the config "allowedUntypedLibraries".
+        const allowedUntypedLibraries: string[] = [];
+        if (configObj.allowedUntypedLibraries !== undefined) {
+            if (!Array.isArray(configObj.allowedUntypedLibraries)) {
+                console.error(`Config "allowedUntypedLibraries" field must contain an array.`);
+            } else {
+                const pathList = configObj.allowedUntypedLibraries as string[];
+                pathList.forEach((lib, libIndex) => {
+                    if (typeof lib !== 'string') {
+                        console.error(`Config "allowedUntypedLibraries" field ${libIndex} must be a string.`);
+                    } else {
+                        allowedUntypedLibraries.push(lib);
+                    }
+                });
+                configRuleSet.allowedUntypedLibraries = allowedUntypedLibraries;
+            }
+        }
+
         this.diagnosticRuleSet = { ...configRuleSet };
 
         // Read the "venvPath".


### PR DESCRIPTION
Basically, this PR adds an `allowedUntypedLibraries` config field which is a list of strings (empty by default). If pyright cannot derive the type of a function, it normally gives an error (`reportUnknownMemberType` or `reportUnknownVariableType`), and if the library the method is implemented in is in this list, it doesn't, for example:

```py
# both foo and bar are untyped, `allowedUntypedLibraries = ["first"]`
from first import foo
from second import bar
foo("123")   # ok
bar("456")   # error
```

Notes:
- Not documented right now
- maybe it's better to name this `allowedUntypedModules` instead of libraries
- maybe it would be good to allow configuring a list of modules deeper than 1 level (i.e. "`library` is strongly typed but `library.new_submodule` isn't"), although I think this is not necessary due to the uses of this feature (the point is that the rule normally targets the code written for the project, and this PR targets the code written for a library used in the project, which are usually not intersecting)

resolves #701