### PR TITLE
eliminate some false positives on `reportUninitializedInstanceVariable`

### DIFF
--- a/docs/benefits-over-pyright/improved-reportUninitializedInstanceVariable.md
+++ b/docs/benefits-over-pyright/improved-reportUninitializedInstanceVariable.md
@@ -1,0 +1,47 @@
+# improved logic for detecting uninitialized instance variables
+
+in pyright, the [`reportUninitializedInstanceVariable`](../configuration/config-files.md#reportUninitializedInstanceVariable) rule will report cases where an instance attribute is defined but not initialized:
+
+```py
+class A:
+    x: int  # error: Instance variable "x" is not initialized in the class body or __init__ method
+
+    def reset(self):
+        # there's no guarantee this will be called so it doesn't count
+        self.x = 3
+```
+
+however, it's very common to write constructors that call a "reset" method. pyright doesn't account for this, so `reportUninitializedInstanceVariable` is still reported even though the attribute will always be initialized.
+
+basedpyright checks the class's `__init__` method for calls to other methods that may initialize instance attributes to eliminate such false positives:
+
+```py
+class A:
+    x: int  # error in pyright, no error in basedpyright
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self):
+        self.x = 3
+```
+
+## limitations
+
+for performance reasons, this only checks one call deep from the `__init__` method, so the following class will still report an error:
+
+```py
+class A:
+    x: int  # reportUninitializedInstanceVariable error
+
+    def __init__(self) -> None:
+        self.initialize()
+
+    def initialize(self):
+        self.reset()
+
+    def reset(self):
+        self.x = 3
+```
+
+although this compromise is not ideal, we've found that this change still eliminates a very common source of false positives for this rule.

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5344,7 +5344,7 @@ export class Checker extends ParseTreeWalker {
                     // if containingClass (that initializes this symbol) is a method that is called in __init__
                     // then we consider this symbol initialized
                     if (containingClass.nodeType === ParseNodeType.Function) {
-                        const initNode = ClassType.getSymbolTable(classType).get('__init__')?.getDeclarations().at(0)
+                        const initNode = ClassType.getSymbolTable(classType).get('__init__')?.getDeclarations()[0]
                             ?.node;
                         if (initNode && initNode.nodeType === ParseNodeType.Function) {
                             return initNode.d.suite.d.statements.some((maybeStatementList) => {

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -5344,18 +5344,18 @@ export class Checker extends ParseTreeWalker {
                     // if containingClass (that initializes this symbol) is a method that is called in __init__
                     // then we consider this symbol initialized
                     if (containingClass.nodeType === ParseNodeType.Function) {
-                        const initNode = ClassType.getSymbolTable(classType).get('__init__')?.getDeclarations()[0]
-                            ?.node;
+                        const initNode = ClassType.getSymbolTable(classType)
+                            .get('__init__')
+                            ?.getDeclarations()[0]?.node;
                         if (initNode && initNode.nodeType === ParseNodeType.Function) {
                             return initNode.d.suite.d.statements.some((maybeStatementList) => {
                                 if (maybeStatementList.nodeType === ParseNodeType.StatementList) {
-                                    return maybeStatementList.d.statements.some((maybeCall) => {
-                                        return (
+                                    return maybeStatementList.d.statements.some(
+                                        (maybeCall) =>
                                             maybeCall.nodeType === ParseNodeType.Call &&
                                             maybeCall.d.leftExpr.nodeType === ParseNodeType.MemberAccess &&
                                             maybeCall.d.leftExpr.d.member.d.value === containingClass.d.name.d.value
-                                        );
-                                    });
+                                    );
                                 }
                                 return false;
                             });

--- a/packages/pyright-internal/src/tests/samples/uninitializedVariableBased1.py
+++ b/packages/pyright-internal/src/tests/samples/uninitializedVariableBased1.py
@@ -1,0 +1,46 @@
+from typing import final
+
+# The objective of this test is to try a bunch of ways
+# to trick the checker into thinking C.x is initialized
+# when it's not initialized.
+
+
+class C:
+    x: int  # should be reported as uninitialized
+
+    def __init__(self) -> None:
+        self.a_method_called_by_init()
+
+        def foo() -> None:  # pyright: ignore[reportUnusedFunction]
+            self.x = 3
+
+    def a_method_not_called_by_init(self) -> None:
+        self.x = 3
+
+    def a_method_called_by_init(self) -> None:
+        # reference x before initializing it
+        self.x += 3
+
+
+def __init__() -> None:
+    c = C()
+    c.x = 3
+
+
+class D:
+    def __init__(self) -> None:
+        c = C()
+        c.x = 3
+
+
+@final
+class E(C):
+    def __init__(self) -> None:
+        super().__init__()
+        self.x = 3
+
+
+class F(C):
+    def __init__(self) -> None:
+        super().__init__()
+        self.x = 3  # pyright: ignore[reportUnannotatedClassAttribute]

--- a/packages/pyright-internal/src/tests/samples/uninitializedVariableBased2.py
+++ b/packages/pyright-internal/src/tests/samples/uninitializedVariableBased2.py
@@ -1,0 +1,8 @@
+class C:
+    x: int  # should not be reported as uninitialized
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.x = 3

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -156,3 +156,20 @@ test('`reportUnusedFunction` on `@final` classes', () => {
         ],
     });
 });
+
+describe('uninitialized variable checking with init method calling', () => {
+    test('uninitialized', () => {
+        const configOptions = new BasedConfigOptions(Uri.empty());
+        const analysisResults = typeAnalyzeSampleFiles(['uninitializedVariableBased1.py'], configOptions);
+        validateResultsButBased(analysisResults, {
+            errors: [{ line: 8, code: DiagnosticRule.reportUninitializedInstanceVariable }],
+        });
+    });
+    test('initialized', () => {
+        const configOptions = new BasedConfigOptions(Uri.empty());
+        const analysisResults = typeAnalyzeSampleFiles(['uninitializedVariableBased2.py'], configOptions);
+        validateResultsButBased(analysisResults, {
+            errors: [],
+        });
+    });
+});


### PR DESCRIPTION
This is a common and good pattern that `reportUninitializedInstanceVariable` currently fails with.

Often we want a class to have a "reset" method to reset it back to its initial state.
But if we initialize everything in `__init__`, that means we're duplicating code, putting it in both `__init__` and in the `reset` method.
So it's better to just put the initializing code in the `reset` method and `__init__` can call the `reset` method.

```python
class C:
    x: int

    def __init__(self) -> None:
        self.reset()

    def reset(self) -> None:
        self.x = 3
```

But the current implementation of `reportUninitializedInstanceVariable` doesn't see `x` as initialized.

This is a fix for this problem.