### PR TITLE
fix "files to analyze" notification hanging on typeshed stubs when they aren't actually being analyzed

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -544,7 +544,7 @@ export class Program {
 
         this._sourceFileList.forEach((fileInfo) => {
             const sourceFile = fileInfo.sourceFile;
-            if (sourceFile.isCheckingRequired()) {
+            if (isUserCode(fileInfo) && sourceFile.isCheckingRequired()) {
                 if (this._shouldCheckFile(fileInfo)) {
                     sourceFile.getIPythonMode() === IPythonMode.CellDocs
                         ? cellsToAnalyzeCount++


### PR DESCRIPTION
as far as i can tell this is an upstream bug that was uncovered by #932

fixes #967 