### PR TITLE
Nvim LSP example documentation

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -103,7 +103,10 @@ require("lspconfig").basedpyright.setup {
     basedpyright = {
       analysis = {
         diagnosticMode = "openFilesOnly",
+        inlayHints = {
+          callArgumentNames = true
         }
+      }
     }
   }
 }


### PR DESCRIPTION
Hi, it is my first attempt to commit into opensource. I switched from pyright to basedpyright and encountered with difference of configuration in my custom nvim build.
I know, how changed configuration in nvim lsp, but in topic chats by nvim/pyright and etc. I often see questions about configurations (in particular about customization of specific parameters). 
When I first saw the pyright documentation (I was a newbie in programming), I didn't undestand how to customize nested attributes. 

That's why I've decided append example of nvim lsp config with nested attributes configuration case.

Another argument - see into emacs example, `inlayHints` is specified, let's make the documentation more consistent in terms of examples
