### PR TITLE
fix import suggestion code actions being disabled when `basedpyright.analysis.autoImportCompletions` is disabled

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -19,6 +19,9 @@ The basedpyright language server honors the following settings.
 
 **basedpyright.analysis.autoImportCompletions** [boolean]: Determines whether pyright offers auto-import completions.
 
+!!! note
+    this setting is only for import suggestion [*completions*](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion), which are displayed as you type. it does not affect [import suggestion *code actions*](../benefits-over-pyright/pylance-features.md#import-suggestion-code-actions), which are tied to the [`reportUndefinedVariable`](./config-files.md#reportUndefinedVariable) diagnostic rule. to disable those, you must disable the diagnostic rule itself.
+
 **basedpyright.analysis.autoSearchPaths** [boolean]: Determines whether pyright automatically adds common search paths like "src" if there are no execution environments defined in the config file.
 
 **basedpyright.analysis.diagnosticMode** ["openFilesOnly", "workspace"]: Determines whether pyright analyzes (and reports errors for) all files in the workspace, as indicated by the config file. If this option is set to "openFilesOnly", pyright analyzes only open files. Defaults to "openFilesOnly"

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -924,7 +924,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                     lazyEdit: false,
                     triggerCharacter: params?.context?.triggerCharacter,
                 },
-                token
+                token,
+                false
             ).getCompletions();
 
             this.setCompletionIncomplete(params, completions);
@@ -953,7 +954,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                         snippet: this.client.completionSupportsSnippet,
                         lazyEdit: false,
                     },
-                    token
+                    token,
+                    false
                 ).resolveCompletionItem(params);
             }, token);
         }

--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -77,7 +77,8 @@ export class CodeActionProvider {
                     lazyEdit: false,
                     snippet: false,
                 },
-                token
+                token,
+                true
             );
 
             const word = node.nodeType === ParseNodeType.Name ? node.d.value : undefined;

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -293,7 +293,8 @@ export class CompletionProvider {
         protected readonly fileUri: Uri,
         protected readonly position: Position,
         protected readonly options: CompletionOptions,
-        protected readonly cancellationToken: CancellationToken
+        protected readonly cancellationToken: CancellationToken,
+        private readonly _codeActions: boolean
     ) {
         this.execEnv = this.configOptions.findExecEnvironment(this.fileUri);
 
@@ -824,7 +825,7 @@ export class CompletionProvider {
         completionMap: CompletionMap,
         parensDisabled?: boolean
     ) {
-        if (!this.configOptions.autoImportCompletions) {
+        if (!this._codeActions && !this.configOptions.autoImportCompletions) {
             // If auto import on the server is turned off or this particular invocation
             // is turned off (ex, notebook), don't do any thing.
             return;

--- a/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
+++ b/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
@@ -58,7 +58,8 @@ test('check chained files', () => {
             lazyEdit: false,
             snippet: false,
         },
-        CancellationToken.None
+        CancellationToken.None,
+        false
     ).getCompletions();
 
     assert(result?.items.some((i) => i.label === 'foo1'));
@@ -105,7 +106,8 @@ test('modify chained files', () => {
             lazyEdit: false,
             snippet: false,
         },
-        CancellationToken.None
+        CancellationToken.None,
+        false
     ).getCompletions();
 
     assert(result);

--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -814,7 +814,8 @@ test('completion quote trigger', async () => {
         uri,
         position,
         options,
-        CancellationToken.None
+        CancellationToken.None,
+        false
     ).getCompletions();
 
     assert(result);
@@ -852,7 +853,8 @@ test('completion quote trigger - middle', async () => {
         uri,
         position,
         options,
-        CancellationToken.None
+        CancellationToken.None,
+        false
     ).getCompletions();
 
     assert.strictEqual(result?.items.length, 0);
@@ -897,7 +899,8 @@ test('auto import sort text', async () => {
         uri,
         position,
         options,
-        CancellationToken.None
+        CancellationToken.None,
+        false
     ).getCompletions();
 
     const items = result?.items.filter((i) => i.label === 'os');

--- a/packages/pyright-internal/src/tests/fourslash/importSuggestion.invokeCodeAction.autoImportCompletionsDisabled.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/importSuggestion.invokeCodeAction.autoImportCompletionsDisabled.fourslash.ts
@@ -1,7 +1,9 @@
 /// <reference path="typings/fourslash.d.ts" />
 
 // @filename: pyrightconfig.json
-//// {}
+//// {
+////   "autoImportCompletions": false
+//// }
 
 // @filename: test.py
 //// [|/*import*/|]foo[|/*noImportMarker*/|]: [|/*startMarker*/|][|TracebackType/*range*/|][|/*endMarker*/|]

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1600,7 +1600,8 @@ export class TestState {
             Uri.file(filePath, this.serviceProvider),
             completionPosition,
             options,
-            CancellationToken.None
+            CancellationToken.None,
+            false
         );
 
         return {


### PR DESCRIPTION
fixes #974