### PR TITLE
Change default to use ".venv" under project root

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -697,6 +697,22 @@ export class AnalyzerService {
         // only apply to the language server.
         this._applyLanguageServerOptions(configOptions, projectRoot, commandLineOptions.languageServerSettings);
 
+        // If project root metadata is found, try to fill missing venvPath or venv
+        if ((configFilePath || pyprojectFilePath) && (!configOptions.venvPath || !configOptions.venv)) {
+            // Use specified venv, or default to '.venv'
+            let venv: string;
+            if (configOptions.venv) {
+                venv = configOptions.venv;
+            } else {
+                venv = '.venv';
+            }
+            const venvUri = projectRoot.resolvePaths(venv);
+            if (this.fs.existsSync(venvUri) && isDirectory(this.fs, venvUri)) {
+                configOptions.venvPath = configOptions.venvPath ?? projectRoot;
+                configOptions.venv = configOptions.venv ?? venv;
+            }
+        }
+
         // Ensure that if no command line or config options were applied, we have some defaults.
         this._ensureDefaultOptions(host, configOptions, projectRoot, executionRoot, commandLineOptions);
 


### PR DESCRIPTION
fixes #365
If project root is found, and ".venv" is found under project root, use that as default.

Project root is found if "pyrightconfig.json" or "pyproject.toml" is found. ".venv" can change to another name by change the '[tool.pyright] venv="venv_name"' in "pyproject.toml". But note that `uv` only support ".venv" so better stick with that.