### PR TITLE
improve documentation for `venv` and `venvPath`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
         "tamasfe.even-better-toml",
         "redhat.vscode-yaml",
         "github.vscode-github-actions",
-        "Orta.vscode-jest"
+        "Orta.vscode-jest",
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -104,5 +104,17 @@
     "npm.exclude": "**/basedpyright/*",
     "git.blame.editorDecoration.enabled": true,
     "git.blame.statusBarItem.enabled": true,
-    "chat.commandCenter.enabled": false
+    "chat.commandCenter.enabled": false, 
+    "yaml.schemas": {
+        "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
+    },
+    "yaml.customTags": [ 
+        "!ENV scalar",
+        "!ENV sequence",
+        "!relative scalar",
+        "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg",
+        "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
+        "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format",
+        "tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify mapping"
+    ]
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,13 +29,13 @@ The following settings control the *environment* in which basedpyright will chec
 
 - **stubPath** [path, optional]: Path to a directory that contains custom type stubs. Each package's type stub file(s) are expected to be in its own subdirectory. The default value of this setting is "./typings". (typingsPath is now deprecated)
 
-- **venvPath** [path, optional]: Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a **venv** setting (see below), pyright will search for imports in the virtual environment’s site-packages directory rather than the paths specified by the default Python interpreter. This setting is ignored when using Pylance. VS Code's python interpreter path is used instead.
+- **venvPath** [path, optional]: Path to a directory containing one or more subdirectories, each of which contains a virtual environment. When used in conjunction with a **venv** setting (see below), pyright will search for imports in the virtual environment’s site-packages directory rather than the paths specified by the default Python interpreter.
 
     !!! note
-        If you are working on a project with other developers and not using a tool like [uv](https://docs.astral.sh/uv/pip/compatibility/#virtual-environments-by-default) or [pdm](https://pdm-project.org/en/latest/usage/venv/#virtualenv-auto-creation), it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a [per-user setting](./language-server-settings.md). For more details, refer to the [import resolution](../usage/import-resolution.md#configuring-your-python-environment) documentation.
+        If you are working on a project with other developers and **not** using a tool like [uv](https://docs.astral.sh/uv/pip/compatibility/#virtual-environments-by-default) or [pdm](https://pdm-project.org/en/latest/usage/venv/#virtualenv-auto-creation), it is best not to specify this setting in the config file, since this path will typically differ for each developer. Instead, it can be specified on the command line or in a [per-user setting](./language-server-settings.md). For more details, refer to the [import resolution](../usage/import-resolution.md#configuring-your-python-environment) documentation.
 
 
-- **venv** [string, optional]: Used in conjunction with the venvPath, specifies the virtual environment to use. For more details, refer to the [import resolution](../usage/import-resolution.md#configuring-your-python-environment) documentation. This setting is ignored when using Pylance.
+- **venv** [string, optional]: Used in conjunction with the venvPath, specifies the virtual environment to use. For more details, refer to the [import resolution](../usage/import-resolution.md#configuring-your-python-environment) documentation.
 
 - **verboseOutput** [boolean]: Specifies whether output logs should be verbose. This is useful when diagnosing certain problems like import resolution issues.
 

--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -1,3 +1,7 @@
+---
+# YAML header
+render_macros: true
+---
 <!--
 most of this file is defined elsewhere and imported here because previous versions of basedpyright contain links to documentation for each diagnostic rule,
 eg. "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues and we don't want to break those links for users

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,21 +42,27 @@ markdown_extensions:
   - pymdownx.snippets
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
 plugins:
   - search
-  - awesome-pages
+  - awesome-pages # https://github.com/squidfunk/mkdocs-material/issues/7563
   # https://github.com/wilhelmer/mkdocs-unused-files/issues/12
   # - unused_files
   - macros:
       module_name: build/docs_macros
       on_undefined: strict
+      render_by_default: false
 nav:
   - index.md
   - ... | benefits-over-pyright/**/*.md
   - ... | installation/**/*.md
+  # https://github.com/squidfunk/mkdocs-material/issues/7563
   - ...
   - ... | development/**/*.md
   - ... | shoutouts.md


### PR DESCRIPTION
fixes #365
```mermaid
flowchart TD
    A{{"are you using vscode?"}} -- YES --> B["use the environment picker in the python extension"]
    A -- NO --> C{{"are you using a virtual environment?"}}
    C -- NO --> E["it should use the correct python interpreter by default, no config required"]
    C -- YES --> D{{"are you launching basedpyright from inside the virtual environment?"}}
    D -- YES --> E
    D -- NO --> F{{"are there other developers working on your project?"}}
    F -- YES --> G{{"is the virtual environment located in the same place on each developer's machine?"}}
    F -- NO --> H["set venv and venvPath in pyproject.toml or pyrightconfig.json"]
    G -- YES --> H
    G -- NO --> I{{"are you using the CLI or the language server?"}}
    I -- CLI --> J["use the --pythonpath CLI argument"]
    I -- language server --> K["set python.pythonPath in your language server config"]
```