### PR TITLE
docs: correct typos and grammar in comments.md

### DIFF
--- a/docs/configuration/comments.md
+++ b/docs/configuration/comments.md
@@ -1,9 +1,9 @@
 # Comments
 
-Some behaviors of pyright can be controlled through the use of comments within the source file.
+Some behaviors of Pyright can be controlled through the use of comments within the source file.
 
 ## File-level Type Controls
-Strict type checking, where most supported type-checking switches generate errors, can be enabled for a file through the use of a special comment. Typically this comment is placed at or near the top of a code file on its own line.
+Strict type checking, where most supported type-checking switches generate errors, can be enabled for a file through the use of a special comment. Typically, this comment is placed at or near the top of a code file on its own line.
 
 ```python
 # pyright: strict
@@ -30,7 +30,7 @@ Diagnostic levels are also supported.
 
 ## Line-level Diagnostic Suppression
 
-PEP 484 defines a special comment `# type: ignore` that can be used at the end of a line to suppress all diagnostics emitted by a type checker on that line. Pyright supports this mechanism. this is disabled by default in basedpyright. [see below](#prefer-pyrightignore-comments) for more information.
+PEP 484 defines a special comment `# type: ignore` that can be used at the end of a line to suppress all diagnostics emitted by a type checker on that line. Pyright supports this mechanism. This is disabled by default in basedpyright. [See below](#prefer-pyrightignore-comments) for more information.
 
 Pyright also supports a `# pyright: ignore` comment at the end of a line to suppress all Pyright diagnostics on that line. This can be useful if you use multiple type checkers on your source base and want to limit suppression of diagnostics to Pyright only.
 
@@ -38,16 +38,16 @@ The `# pyright: ignore` comment accepts an optional list of comma-delimited diag
 
 If the `reportUnnecessaryTypeIgnoreComment` configuration option is enabled, any unnecessary `# type: ignore` and `# pyright: ignore` comments will be reported so they can be removed.
 
-### prefer `# pyright:ignore` comments
+### Prefer `# pyright:ignore` comments
 
-`# pyright:ignore` comments are preferred over `# type:ignore` comments because they are more strict than `#type:ignore` comments:
+`# pyright:ignore` comments are preferred over `# type:ignore` comments because they are more strict than `# type:ignore` comments:
 
-- `# type:ignore` comments will always suppress all errors on the line, regardless of what diagnostic rules are specified in brackets
-- `# type:ignore` comments are not checked to ensure that the specified rule is valud:
+- `# type:ignore` comments will always suppress all errors on the line, regardless of what diagnostic rules are specified in brackets.
+- `# type:ignore` comments are not checked to ensure that the specified rule is valid:
   ```py
-  # no error here, even though you are suppressing an invalid diagnostic code.
+  # No error here, even though you are suppressing an invalid diagnostic code.
   1 + "" # type:ignore[asdf]
   ```
-  this decision was probably made to support other type checkers like mypy which use different codes to pyright, but in that case you should just disable `enableTypeIgnoreComments` to prevent pyright from looking at them.
+  This decision was probably made to support other type checkers like mypy which use different codes to Pyright, but in that case, you should just disable `enableTypeIgnoreComments` to prevent Pyright from looking at them.
 
-in basedpyright, `enableTypeIgnoreComments` is disabled by default to avoid these issues.
+In basedpyright, `enableTypeIgnoreComments` is disabled by default to avoid these issues.


### PR DESCRIPTION
Some minor typo/syntax/grammar touch ups to the Configuration/Comments docs I noticed while RTFMing.