### PR TITLE
add deprecated tag to completions

### DIFF
--- a/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
+++ b/packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
@@ -53,6 +53,7 @@ import {
     Variance,
 } from './types';
 import { ApplyTypeVarOptions, ClassMember, InferenceContext, MemberAccessFlags } from './typeUtils';
+import { DeprecatedForm } from './deprecatedSymbols';
 
 // Maximum number of unioned subtypes for an inferred type (e.g.
 // a list) before the type is considered an "Any".
@@ -894,4 +895,10 @@ export interface TypeEvaluator {
     ) => void;
     typesOverlap: (leftType: Type, rightType: Type, checkEq: boolean) => boolean;
     markParamAccessed: (param: ParameterNode) => void;
+    deprecatedTypingAlias: (
+        fileInfo: AnalyzerFileInfo,
+        name: string,
+        type: Type,
+        isImportFromTyping: boolean
+    ) => DeprecatedForm | undefined;
 }

--- a/packages/pyright-internal/src/common/languageServerInterface.ts
+++ b/packages/pyright-internal/src/common/languageServerInterface.ts
@@ -120,6 +120,7 @@ export interface ClientCapabilities {
     supportsUnnecessaryDiagnosticTag: boolean;
     supportsTaskItemDiagnosticTag: boolean;
     completionItemResolveSupportsAdditionalTextEdits: boolean;
+    completionItemResolveSupportsTags: boolean;
 }
 
 export interface LanguageServerBaseInterface {

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -188,6 +188,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         supportsUnnecessaryDiagnosticTag: false,
         supportsTaskItemDiagnosticTag: false,
         completionItemResolveSupportsAdditionalTextEdits: false,
+        completionItemResolveSupportsTags: false,
     };
 
     protected defaultClientConfig: any;
@@ -610,10 +611,11 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         this.client.supportsTaskItemDiagnosticTag = this.client.hasVisualStudioExtensionsCapability;
         this.client.hasWindowProgressCapability = !!capabilities.window?.workDoneProgress;
         this.client.hasGoToDeclarationCapability = !!capabilities.textDocument?.declaration;
+        const completionResolveProperties =
+            capabilities.textDocument?.completion?.completionItem?.resolveSupport?.properties ?? [];
         this.client.completionItemResolveSupportsAdditionalTextEdits =
-            !!capabilities.textDocument?.completion?.completionItem?.resolveSupport?.properties.some(
-                (p) => p === 'additionalTextEdits'
-            );
+            completionResolveProperties.includes('additionalTextEdits');
+        this.client.completionItemResolveSupportsTags = completionResolveProperties.includes('tags');
 
         // Create a service instance for each of the workspace folders.
         this.workspaceFactory.handleInitialize(params);
@@ -972,6 +974,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                     snippet: this.client.completionSupportsSnippet,
                     lazyEdit: false,
                     triggerCharacter: params?.context?.triggerCharacter,
+                    checkDeprecatedWhenResolving: this.client.completionItemResolveSupportsTags,
                 },
                 token,
                 false
@@ -1002,6 +1005,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                         format: this.client.completionDocFormat,
                         snippet: this.client.completionSupportsSnippet,
                         lazyEdit: false,
+                        checkDeprecatedWhenResolving: this.client.completionItemResolveSupportsTags,
                     },
                     token,
                     false

--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -78,6 +78,9 @@ export class CodeActionProvider {
                     format: 'plaintext',
                     lazyEdit: false,
                     snippet: false,
+                    // we don't care about deprecations here so make sure they don't get evaluated unnecessarily
+                    // (we don't call resolveCompletionItem)
+                    checkDeprecatedWhenResolving: true,
                 },
                 token,
                 true

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -12,6 +12,7 @@ import {
     CancellationToken,
     CompletionItem,
     CompletionItemKind,
+    CompletionItemTag,
     CompletionList,
     InsertTextFormat,
     MarkupKind,
@@ -721,6 +722,10 @@ export class CompletionProvider {
             if (!type) {
                 // Can't resolve. so bail out.
                 return;
+            }
+
+            if ((isFunction(type) || isClass(type)) && type.shared.deprecatedMessage !== undefined) {
+                this.itemToResolve.tags = [CompletionItemTag.Deprecated];
             }
 
             const typeDetail = getTypeDetail(

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -704,7 +704,15 @@ export class CompletionProvider {
         // https://github.com/Saghen/blink.cmp/issues/1221
         const type = this.evaluator.getEffectiveTypeOfSymbol(symbol);
 
-        const isDeprecated = (isFunction(type) || isClass(type)) && type.shared.deprecatedMessage !== undefined;
+        const isDeprecated =
+            ((isFunction(type) || isClass(type)) && type.shared.deprecatedMessage !== undefined) ||
+            (primaryDecl &&
+                !!this.evaluator.deprecatedTypingAlias(
+                    AnalyzerNodeInfo.getFileInfo(primaryDecl.node),
+                    name,
+                    type,
+                    detail.autoImportSource === 'typing'
+                ));
 
         // Are we resolving a completion item? If so, see if this symbol
         // is the one that we're trying to match.

--- a/packages/pyright-internal/src/languageService/completionProviderUtils.ts
+++ b/packages/pyright-internal/src/languageService/completionProviderUtils.ts
@@ -58,6 +58,7 @@ export interface CompletionDetail extends CommonDetail {
     sortText?: string;
     itemDetail?: string;
     moduleUri?: Uri;
+    deprecated?: boolean;
 }
 
 export function getTypeDetail(

--- a/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
+++ b/packages/pyright-internal/src/tests/chainedSourceFiles.test.ts
@@ -57,6 +57,7 @@ test('check chained files', () => {
             format: MarkupKind.Markdown,
             lazyEdit: false,
             snippet: false,
+            checkDeprecatedWhenResolving: false,
         },
         CancellationToken.None,
         false
@@ -105,6 +106,7 @@ test('modify chained files', () => {
             format: MarkupKind.Markdown,
             lazyEdit: false,
             snippet: false,
+            checkDeprecatedWhenResolving: false,
         },
         CancellationToken.None,
         false

--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -6,7 +6,7 @@
 
 import assert from 'assert';
 import { CancellationToken } from 'vscode-languageserver';
-import { CompletionItemKind, MarkupKind } from 'vscode-languageserver-types';
+import { CompletionItemKind, CompletionItemTag, MarkupKind } from 'vscode-languageserver-types';
 
 import { Uri } from '../common/uri/uri';
 import { CompletionOptions, CompletionProvider } from '../languageService/completionProvider';
@@ -1492,6 +1492,33 @@ test('dataclass field alias with invalid python identifier', async () => {
                 {
                     label: 'foo bar=',
                     kind: CompletionItemKind.Variable,
+                },
+            ],
+        },
+    });
+});
+
+test('deprecated', async () => {
+    const code = `
+// @filename: test.py
+//// from typing_extensions import deprecated
+//// 
+//// 
+//// @deprecated('asdf')
+//// def asdfasdf(): ...
+//// 
+//// asdfasd[|/*marker*/|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    await state.verifyCompletion('included', 'markdown', {
+        ['marker']: {
+            completions: [
+                {
+                    label: 'asdfasdf',
+                    kind: CompletionItemKind.Function,
+                    tags: [CompletionItemTag.Deprecated],
                 },
             ],
         },

--- a/packages/pyright-internal/src/tests/fourslash/typings/fourslash.d.ts
+++ b/packages/pyright-internal/src/tests/fourslash/typings/fourslash.d.ts
@@ -22,6 +22,9 @@
  * and hit F5.
  */
 
+// TODO: use declare global and just re-export the types from vscode-languageserver-types instead of duplicating them
+// but that might be annoying for upstream merges because it involves indenting everything
+
 declare namespace _ {
     type CompletionItemKind =
         | 1
@@ -51,6 +54,9 @@ declare namespace _ {
         | 25;
 
     type FourSlashVerificationMode = 'exact' | 'included' | 'excluded';
+
+    type CompletionItemTag = 1;
+
     interface FourSlashCompletionItem {
         label: string;
         kind: CompletionItemKind | undefined;
@@ -61,6 +67,7 @@ declare namespace _ {
         additionalTextEdits?: TextEdit[];
         detailDescription?: string;
         commitCharacters?: string[];
+        tags?: CompletionItemTag[];
     }
 
     interface FourSlashCallHierarchyItem {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -99,6 +99,7 @@ import {
 } from './testStateUtils';
 import { verifyWorkspaceEdit } from './workspaceEditTestUtils';
 import { Host } from '../../../common/host';
+import { tExpect } from 'typed-jest-expect';
 
 export interface TextChange {
     span: TextRange;
@@ -1061,10 +1062,11 @@ export class TestState {
 
                         const actual: CompletionItem = results.items[actualIndex];
 
-                        if (expected.additionalTextEdits !== undefined) {
-                            if (actual.additionalTextEdits === undefined) {
-                                provider.resolveCompletionItem(actual);
-                            }
+                        if (
+                            (expected.additionalTextEdits !== undefined && actual.additionalTextEdits === undefined) ||
+                            (expected.tags !== undefined && actual.tags === undefined)
+                        ) {
+                            provider.resolveCompletionItem(actual);
                         }
 
                         this.verifyCompletionItem(expected, actual);
@@ -1710,6 +1712,7 @@ export class TestState {
         assert.strictEqual(actual.label, expected.label);
         assert.strictEqual(actual.detail, expected.detail);
         assert.strictEqual(actual.kind, expected.kind);
+        tExpect(actual.tags).toStrictEqual(expected.tags);
 
         assert.strictEqual(actual.insertText, expected.insertionText);
         this._verifyEdit(actual.textEdit as TextEdit, expected.textEdit);

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -1013,7 +1013,8 @@ export class TestState {
                 readonly importFrom?: string;
                 readonly importName: string;
             };
-        }
+        },
+        resolveTags = false
     ): Promise<void> {
         this.analyze();
 
@@ -1026,7 +1027,7 @@ export class TestState {
             this.lastKnownMarker = markerName;
 
             const expectedCompletions = map[markerName].completions;
-            const provider = this.getCompletionResults(this, marker, docFormat, abbrMap);
+            const provider = this.getCompletionResults(this, marker, docFormat, resolveTags, abbrMap);
             const results = provider.getCompletions();
             if (results) {
                 if (verifyMode === 'exact') {
@@ -1064,7 +1065,7 @@ export class TestState {
 
                         if (
                             (expected.additionalTextEdits !== undefined && actual.additionalTextEdits === undefined) ||
-                            (expected.tags !== undefined && actual.tags === undefined)
+                            (resolveTags && expected.tags !== undefined && actual.tags === undefined)
                         ) {
                             provider.resolveCompletionItem(actual);
                         }
@@ -1613,6 +1614,7 @@ export class TestState {
         state: TestState,
         marker: Marker,
         docFormat: MarkupKind,
+        resolveTags: boolean,
         abbrMap?: {
             [abbr: string]: {
                 readonly importFrom?: string;
@@ -1627,6 +1629,7 @@ export class TestState {
             format: docFormat,
             snippet: true,
             lazyEdit: false,
+            checkDeprecatedWhenResolving: resolveTags,
         };
 
         const provider = new CompletionProvider(


### PR DESCRIPTION
fixes #1078

doesn't work and i can't figure out why. something to do with `onCompletion` and `onCompletionResolve`. if i add the tag in `onCOmpletion` it works but if i do it in `onCompletionResolve` it doesn't, buit i don't think adding it to `onCompletion` is a good idea because it needs to evaluate the type of all the completion items which would probably be bad for performance