### PR TITLE
fix: include `DiagnosticTag.Deprecated` for all severity levels of `reportDeprecated`

### DIFF
--- a/packages/pyright-internal/src/common/languageServerInterface.ts
+++ b/packages/pyright-internal/src/common/languageServerInterface.ts
@@ -116,8 +116,6 @@ export interface ClientCapabilities {
     completionDocFormat: MarkupKind;
     completionSupportsSnippet: boolean;
     signatureDocFormat: MarkupKind;
-    supportsDeprecatedDiagnosticTag: boolean;
-    supportsUnnecessaryDiagnosticTag: boolean;
     supportsTaskItemDiagnosticTag: boolean;
     completionItemResolveSupportsAdditionalTextEdits: boolean;
 }

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1786,33 +1786,25 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             const code = this.getDiagCode(diag, rule);
             const vsDiag = Diagnostic.create(diag.range, diag.message, severity, code, this.serverOptions.productName);
 
-            if (diag.category === DiagnosticCategory.Hint) {
-                if (diag.baselined) {
-                    vsDiag.message = `Baselined: ${vsDiag.message}`;
-                }
-                if (deprecatedDiagnosticRules().includes(rule)) {
-                    // If the client doesn't support "deprecated" tags, don't report deprecated diagnostics unless it's a baselined error.
-                    if (!this.client.supportsDeprecatedDiagnosticTag && !diag.baselined) {
-                        return;
-                    }
-                    vsDiag.tags = [DiagnosticTag.Deprecated];
-                } else if ([...unreachableDiagnosticRules(), ...unusedDiagnosticRules()].includes(rule)) {
-                    // If the client doesn't support "unnecessary" tags, don't report unused code unless it's a baselined error.
-                    if (!this.client.supportsUnnecessaryDiagnosticTag && !diag.baselined) {
-                        return;
-                    }
-                    vsDiag.tags = [DiagnosticTag.Unnecessary];
-                }
-                vsDiag.severity = DiagnosticSeverity.Hint;
-            } else {
-                assert(
-                    !diag.baselined,
-                    `a baselined diagnostic somehow had the wrong diagnostic category: ${diag.message} (${diag.category})`
-                );
-                if (diag.category === DiagnosticCategory.TaskItem) {
-                    // TaskItem is not supported.
+            if (diag.category === DiagnosticCategory.TaskItem) {
+                // TaskItem is not supported.
+                return;
+            }
+            if (diag.baselined) {
+                vsDiag.message = `Baselined: ${vsDiag.message}`;
+            }
+            if (deprecatedDiagnosticRules().includes(rule)) {
+                // If the client doesn't support "deprecated" tags, don't report deprecated diagnostics unless it's a baselined error.
+                if (!this.client.supportsDeprecatedDiagnosticTag && !diag.baselined) {
                     return;
                 }
+                vsDiag.tags = [DiagnosticTag.Deprecated];
+            } else if ([...unreachableDiagnosticRules(), ...unusedDiagnosticRules()].includes(rule)) {
+                // If the client doesn't support "unnecessary" tags, don't report unused code unless it's a baselined error.
+                if (!this.client.supportsUnnecessaryDiagnosticTag && !diag.baselined) {
+                    return;
+                }
+                vsDiag.tags = [DiagnosticTag.Unnecessary];
             }
             if (rule) {
                 const ruleDocUrl = this.getDocumentationUrlForDiagnostic(diag);

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -148,7 +148,6 @@ import { website } from './constants';
 import { SemanticTokensProvider, SemanticTokensProviderLegend } from './languageService/semanticTokensProvider';
 import { RenameUsageFinder } from './analyzer/renameUsageFinder';
 import { BaselineHandler } from './baseline';
-import { assert } from './common/debug';
 import { AutoImporter, buildModuleSymbolsMap } from './languageService/autoImporter';
 import { zip } from 'lodash';
 

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -150,6 +150,7 @@ import { RenameUsageFinder } from './analyzer/renameUsageFinder';
 import { BaselineHandler } from './baseline';
 import { AutoImporter, buildModuleSymbolsMap } from './languageService/autoImporter';
 import { zip } from 'lodash';
+import { assert } from './common/debug';
 
 export abstract class LanguageServerBase implements LanguageServerInterface, Disposable {
     // We support running only one "find all reference" at a time.
@@ -1782,6 +1783,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             }
             if (diag.baselined) {
                 vsDiag.message = `Baselined: ${vsDiag.message}`;
+                assert(
+                    diag.category === DiagnosticCategory.Hint,
+                    `a baselined diagnostic somehow had the wrong diagnostic category: ${diag.message} (${diag.category})`
+                );
             }
             if (deprecatedDiagnosticRules().includes(rule)) {
                 vsDiag.tags = [DiagnosticTag.Deprecated];


### PR DESCRIPTION
Related to https://github.com/DetachHead/basedpyright/issues/1081#issuecomment-2659223968
