### PR TITLE
Fix workspace diagnosticMode in BasedPyright

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1821,7 +1821,7 @@
                     "description": "Disables the “Organize Imports” command.",
                     "scope": "resource"
                 },
-                "pyright.disablePullDiagnostics": {
+                "basedpyright.disablePullDiagnostics": {
                     "type": "boolean",
                     "default": false,
                     "description": "Disables the use of pull diagnostics from VS Code.",

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -261,7 +261,7 @@ export async function activate(context: ExtensionContext) {
         },
         initializationOptions: {
             diagnosticMode: workspace.getConfiguration('basedpyright.analysis').get('diagnosticMode'),
-            disablePullDiagnostics: workspace.getConfiguration('pyright').get('disablePullDiagnostics'),
+            disablePullDiagnostics: workspace.getConfiguration('basedpyright').get('disablePullDiagnostics'),
         },
     };
 

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -260,7 +260,7 @@ export async function activate(context: ExtensionContext) {
             },
         },
         initializationOptions: {
-            diagnosticMode: workspace.getConfiguration('python.analysis').get('diagnosticMode'),
+            diagnosticMode: workspace.getConfiguration('basedpyright.analysis').get('diagnosticMode'),
             disablePullDiagnostics: workspace.getConfiguration('pyright').get('disablePullDiagnostics'),
         },
     };


### PR DESCRIPTION
The `workspace` diagnosticMode is broken due to the changes introduced in [this commit](https://github.com/DetachHead/basedpyright/commit/bad0c199d44d64b0018e485e4c794846ac04d8ad).

TL;DR: the setting uses the wrong key (`python.analysis` instead of `basedpyright.analysis`) [here](https://github.com/DetachHead/basedpyright/blob/57f2e36bc3a22bc017d614b5374ad6928b3cab0f/packages/vscode-pyright/src/extension.ts#L263).

Less TL;DR: Because of this, we send `undefined` as the diagnostic mode to the language server, which messes up [this condition](https://github.com/DetachHead/basedpyright/blob/57f2e36bc3a22bc017d614b5374ad6928b3cab0f/packages/pyright-internal/src/languageServerBase.ts#L633), and we end up [skipping the workspace analysis](https://github.com/DetachHead/basedpyright/blob/main/packages/pyright-internal/src/analyzer/service.ts#L502).

~~Maybe the `disablePullDiagnostics` option should be exposed as well?~~ This PR also fixes the naming for the `disablePullDiagnostics` setting.