### PR TITLE
Update documentation for locale configurations

### DIFF
--- a/docs/benefits-over-pyright/improved-translations.md
+++ b/docs/benefits-over-pyright/improved-translations.md
@@ -1,5 +1,11 @@
-# improved translations
+# localization fixes
+
+## improved translations
 
 the translations in pyright come from microsoft's localization team, who are not programmers. not only does this result in poor quality translations, but microsoft also doesn't accept contributions to fix them ([more info here](https://github.com/microsoft/pyright/issues/7441#issuecomment-1987027067)).
 
 we accept translation fixes in basedpyright. [see the localization guidelines](../development/localization.md) for information on how to contribute.
+
+## fixed country code format for linux
+
+in pyright, you can configure the locale using [environment variables](../configuration/config-files.md#locale-configuration) in `"en-US"` format. this format is commonly used on windows, but linux uses the `"en_US"` format instead. unlike pyright, basedpyright supports both formats.

--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -434,13 +434,15 @@ for more information about why this is the case, [see here](./language-server-se
 
 ## Locale Configuration
 
-Pyright provides diagnostic messages that are translated to multiple languages. By default, pyright uses the default locale of the operating system. You can override the desired locale through the use of one of the following environment variables, listed in priority order.
+Pyright provides diagnostic messages that are translated to multiple languages, which are improved in basedpyright thanks to [community-contributed translations](../development/localization.md). By default, basedpyright uses the default locale of the operating system. You can override the desired locale through the use of one of the following environment variables, listed in priority order.
 
 ```
 LC_ALL="de"
 LC_MESSAGES="en-us"
-LANG="zh-cn"
+LANG="zh_CN"
 LANGUAGE="fr"
 ```
+
+The locale specifiers can be `xx-xx` or `xx_XX` in basedpyright. The latter form is used in unix-like platforms, which is not supported in pyright.
 
 When running in VS Code, the editor's locale takes precedence. Setting these environment variables applies only when using pyright outside of VS Code.


### PR DESCRIPTION
Update the documentation since basedpyright has already supported the unix-like locale specifiers (`xx_XX`).

fixes #1040