### PR TITLE
remove dependency on python vscode extension and fix pylance check when the python extension isn't installed

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1892,9 +1892,6 @@
             }
         ]
     },
-    "extensionDependencies": [
-        "ms-python.python"
-    ],
     "scripts": {
         "clean": "shx rm -rf ./dist ./out README.md",
         "prepack": "npm run clean && shx cp ../../README.md . && shx cp ../../LICENSE.txt . && npm run build",

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -62,7 +62,12 @@ export async function activate(context: ExtensionContext) {
     const moreInfo = 'More info';
     const disableBasedPyrightLsp = () =>
         workspace.getConfiguration('basedpyright').update('disableLanguageServices', true);
-    if (pyrightLanguageServerEnabled && languageServerSetting !== 'None') {
+    if (
+        pyrightLanguageServerEnabled &&
+        // undefined if the python extension isn't installed
+        languageServerSetting &&
+        languageServerSetting !== 'None'
+    ) {
         const disablePythonLanguageServer = 'fix setting & use basedpyright LSP (recommended)';
         const keepUsingExistingLanguageServer = `disable basedpyright LSP`;
         const result = await window.showWarningMessage(


### PR DESCRIPTION
fixes #1147
partially addresses #1165