### PR TITLE
add support for caching stdlib packages

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1962,8 +1962,21 @@ export class ImportResolver {
                         readDir(dirRoot, prefix ? `${prefix}.${entry.name}` : entry.name);
                     } else if (entry.name.includes('.py')) {
                         const stripped = stripFileExtension(entry.name);
-                        // Skip anything starting with an underscore.
-                        if (!stripped.startsWith('_')) {
+                        // Allow __init__.py but skip other files starting with underscore
+                        if (stripped === '__init__' && prefix) {
+                            // If we find an __init__.py, add the package to the cache
+                            if (
+                                this._isStdlibTypeshedStubValidForVersion(
+                                    createImportedModuleDescriptor(prefix),
+                                    root,
+                                    executionEnvironment.pythonVersion,
+                                    executionEnvironment.pythonPlatform,
+                                    []
+                                )
+                            ) {
+                                cache.add(prefix);
+                            }
+                        } else if (!stripped.startsWith('_')) {
                             if (
                                 this._isStdlibTypeshedStubValidForVersion(
                                     createImportedModuleDescriptor(stripped),

--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -1839,3 +1839,42 @@ describe('useTypingExtensions', () => {
         });
     });
 });
+
+test('import from stdlib package', async () => {
+    const code = `
+// @filename: test.py
+//// [|/*marker0*/|]
+//// [|/*importMarker*/|][|JSONDecodeErr/*marker*/|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    await state.verifyCompletion(
+        'included',
+        'markdown',
+        {
+            ['marker']: {
+                completions: [
+                    {
+                        label: 'JSONDecodeError',
+                        kind: CompletionItemKind.Class,
+                        detail: 'Auto-import',
+                        textEdit: {
+                            range: state.getPositionRange('marker'),
+                            newText: 'JSONDecodeError',
+                        },
+                        additionalTextEdits: [
+                            {
+                                range: state.getPositionRange('importMarker'),
+                                newText: 'from json import JSONDecodeError\n\n\n',
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        undefined,
+        undefined,
+        false
+    );
+});

--- a/packages/pyright-internal/src/tests/fourslash/completions.builtinOverride.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.builtinOverride.fourslash.ts
@@ -1,7 +1,7 @@
 /// <reference path="typings/fourslash.d.ts" />
 
 // @filename: test.py
-//// Custo[|/*marker1*/|]
+//// CustomCl[|/*marker1*/|]
 //// my_v[|/*marker2*/|]
 
 // @filename: __builtins__.pyi

--- a/packages/pyright-internal/src/tests/fourslash/completions.dictionary.keys.stringLiterals.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.dictionary.keys.stringLiterals.fourslash.ts
@@ -25,7 +25,7 @@
 // @filename: dict_key_name_conflicts.py
 //// keyString = "key"
 //// d = dict(keyString=1)
-//// d[[|keyStr/*marker6*/|]]
+//// d[[|keyStri/*marker6*/|]]
 
 // @filename: dict_key_mixed_literals.py
 //// d = { "key": 1, 1 + 2: 1 }

--- a/packages/pyright-internal/src/tests/fourslash/shadowedImports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/shadowedImports.fourslash.ts
@@ -41,7 +41,8 @@
 ////     ...|]
 
 // @filename: ctypes/__init__.py
-//// # This should be flagged as a module
+//// [|/*marker0*/def bar():
+////     ...|]
 
 // @filename: test.py
 //// import [|/*marker2*/ctypes.util|]
@@ -53,6 +54,10 @@
 ////
 // @ts-ignore
 await helper.verifyDiagnostics({
+    marker0: {
+        category: 'warning',
+        message: `"${helper.getPathSep()}ctypes${helper.getPathSep()}__init__.py" is overriding the stdlib module "ctypes"`,
+    },
     marker1: {
         category: 'warning',
         message: `"${helper.getPathSep()}ctypes${helper.getPathSep()}util.py" is overriding the stdlib module "ctypes.util"`,


### PR DESCRIPTION
close #1172 

don't ignore `/__init__.pyi` files in the cache walk