### PR TITLE
fix `reportPrivateImportUsage` behaving differently when run on an individual file if imports in other files effect the cached import results

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -2388,7 +2388,14 @@ export class ImportResolver {
             importName,
             importFailureInfo,
             /* allowPartial */ false,
-            /* allowNativeLib */ true
+            /* allowNativeLib */ true,
+            false,
+            true,
+            // needed to prevent https://github.com/DetachHead/basedpyright/issues/1171
+            // not entirely sure if this is the correct fix. it seems to be some cache related issue because
+            // this argument can change the result of isModulePrivate but the cache stored in _cachedImportResults
+            // doesn't seem to account for that
+            true
         );
 
         if (absImport && absImport.isStubFile) {

--- a/packages/pyright-internal/src/tests/fourslash/import.pytyped.reportPrivateImportUsageIssue.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/import.pytyped.reportPrivateImportUsageIssue.fourslash.ts
@@ -1,0 +1,42 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: pyrightconfig.json
+//// {
+////   "reportPrivateImportUsage": "error"
+//// }
+
+// @filename: a/py.typed
+// @library: true
+////
+
+// @filename: a/__init__.py
+// @library: true
+//// from ._b import C as C
+
+// @filename: a/_b.py
+// @library: true
+//// class C: ...
+//// class _D: ...
+
+// repro of https://github.com/DetachHead/basedpyright/issues/1171
+// the order of these two files matters! b/d.py must be evaluated first to reproduce it
+
+// @filename: b/d.py
+//// from a import [|/*marker2*/C|]
+
+// @filename: b/c/main.py
+//// from a._b import [|/*marker1*/_D|]
+
+helper.openFiles(helper.getMarkers().map((m) => m.fileName));
+// https://github.com/DetachHead/basedpyright/issues/86
+// @ts-expect-error
+await helper.verifyDiagnostics({
+    marker1: {
+        category: 'error',
+        message: `"_D" is not exported from module "a._b"`,
+    },
+    marker2: {
+        category: 'hint',
+        message: `Import "C" is not accessed`,
+    },
+});


### PR DESCRIPTION
fixes #1171