### PR TITLE
Don't cache private stdlib packages

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1963,7 +1963,7 @@ export class ImportResolver {
                     } else if (entry.name.includes('.py')) {
                         const stripped = stripFileExtension(entry.name);
                         // Allow __init__.py but skip other files starting with underscore
-                        if (stripped === '__init__' && prefix) {
+                        if (stripped === '__init__' && prefix && !prefix.startsWith('_')) {
                             // If we find an __init__.py, add the package to the cache
                             if (
                                 this._isStdlibTypeshedStubValidForVersion(


### PR DESCRIPTION
amendment to #1173 
we shouldn't add private stdlib packages when building the stdlib cache

I think in practice the only private package in the typeshed stdlib is `_typeshed/__init__.pyi`, but it probably makes sense to preserve the "don't cache private modules" for packages too.

