### PR TITLE
Add configurable file enumeration timeout settings

### DIFF
--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -46,6 +46,8 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownVariableType`](#reportUnknownVariableType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
+- <a name="fileEnumerationTimeoutInSec"></a> **fileEnumerationTimeoutInSec** [integer, optional]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely.
+
 ## Type Evaluation Settings
 
 The following settings determine how different types should be evaluated.

--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -59,8 +59,6 @@ the following settings are exclusive to basedpyright
 
 **basedpyright.analysis.fileEnumerationTimeout** [integer]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely. Increase this value if you have a large workspace and don't want to see the warning.
 
-**basedpyright.analysis.fileEnumerationMinimumFiles** [integer]: Minimum number of files that need to be visited before showing a "slow enumeration" warning. Default is 50 files. Increase this value to reduce warnings in large workspaces where you expect many files to be scanned.
-
 ### discouraged settings
 
 these options can also be configured [using a config file](./config-files.md). it's recommended to use either a `pyproject.toml` or `pyrightconfig.json` file instead of the language server to configure type checking for the following reasons:

--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -57,6 +57,10 @@ the following settings are exclusive to basedpyright
 
 **basedpyright.analysis.useTypingExtensions** [boolean]: Whether to rely on imports from the `typing_extensions` module when targeting older versions of python that do not include certain typing features such as the `@override` decorator. Defaults to `false`. [more info](../benefits-over-pyright/language-server-improvements.md#autocomplete-improvements)
 
+**basedpyright.analysis.fileEnumerationTimeout** [integer]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely. Increase this value if you have a large workspace and don't want to see the warning.
+
+**basedpyright.analysis.fileEnumerationMinimumFiles** [integer]: Minimum number of files that need to be visited before showing a "slow enumeration" warning. Default is 50 files. Increase this value to reduce warnings in large workspaces where you expect many files to be scanned.
+
 ### discouraged settings
 
 these options can also be configured [using a config file](./config-files.md). it's recommended to use either a `pyproject.toml` or `pyrightconfig.json` file instead of the language server to configure type checking for the following reasons:

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -922,10 +922,6 @@ export class AnalyzerService {
             configOptions.fileEnumerationTimeoutInSec = languageServerOptions.fileEnumerationTimeoutInSec;
         }
 
-        if (languageServerOptions.fileEnumerationMinimumFiles !== undefined) {
-            configOptions.fileEnumerationMinimumFiles = languageServerOptions.fileEnumerationMinimumFiles;
-        }
-
         // Special case, the language service can also set a pythonPath. It should override any other setting.
         if (languageServerOptions.pythonPath) {
             this._console.info(
@@ -1388,10 +1384,7 @@ export class AnalyzerService {
                 ? 10
                 : this._configOptions.fileEnumerationTimeoutInSec;
         // Use configurable min files or default to 50 files
-        const nFilesToSuggestSubfolder =
-            this._configOptions.fileEnumerationMinimumFiles === undefined
-                ? 50
-                : this._configOptions.fileEnumerationMinimumFiles;
+        const nFilesToSuggestSubfolder = 50;
         let loggedLongOperationError = false;
         let nFilesVisited = 0;
 
@@ -1401,11 +1394,7 @@ export class AnalyzerService {
 
                 // If this is taking a long time, log an error to help the user
                 // diagnose and mitigate the problem.
-                if (
-                    longOperationLimitInSec > 0 &&
-                    secondsSinceStart >= longOperationLimitInSec &&
-                    nFilesVisited >= nFilesToSuggestSubfolder
-                ) {
+                if (secondsSinceStart >= longOperationLimitInSec && nFilesVisited >= nFilesToSuggestSubfolder) {
                     (this._console as ConsoleInterface).error(
                         `Enumeration of workspace source files is taking longer than ${longOperationLimitInSec} seconds.\n` +
                             'This may be because:\n' +

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1384,14 +1384,14 @@ export class AnalyzerService {
         const startTime = Date.now();
         // Use configurable timeout or default to 10 seconds
         const longOperationLimitInSec =
-            this._configOptions.fileEnumerationTimeoutInSec !== undefined
-                ? this._configOptions.fileEnumerationTimeoutInSec
-                : 10;
+            this._configOptions.fileEnumerationTimeoutInSec === undefined
+                ? 10
+                : this._configOptions.fileEnumerationTimeoutInSec;
         // Use configurable min files or default to 50 files
         const nFilesToSuggestSubfolder =
-            this._configOptions.fileEnumerationMinimumFiles !== undefined
-                ? this._configOptions.fileEnumerationMinimumFiles
-                : 50;
+            this._configOptions.fileEnumerationMinimumFiles === undefined
+                ? 50
+                : this._configOptions.fileEnumerationMinimumFiles;
         let loggedLongOperationError = false;
         let nFilesVisited = 0;
 

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1383,7 +1383,6 @@ export class AnalyzerService {
             this._configOptions.fileEnumerationTimeoutInSec === undefined
                 ? 10
                 : this._configOptions.fileEnumerationTimeoutInSec;
-        // Use configurable min files or default to 50 files
         const nFilesToSuggestSubfolder = 50;
 
         let loggedLongOperationError = false;

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -1385,6 +1385,7 @@ export class AnalyzerService {
                 : this._configOptions.fileEnumerationTimeoutInSec;
         // Use configurable min files or default to 50 files
         const nFilesToSuggestSubfolder = 50;
+
         let loggedLongOperationError = false;
         let nFilesVisited = 0;
 

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -141,9 +141,6 @@ export class CommandLineLanguageServerOptions {
     // Override default timeout (in seconds) for file enumeration operations.
     fileEnumerationTimeoutInSec?: number;
 
-    // Override minimum number of files to visit before showing warning.
-    fileEnumerationMinimumFiles?: number;
-
     // Run ambient analysis.
     enableAmbientAnalysis = true;
 

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -138,6 +138,12 @@ export class CommandLineLanguageServerOptions {
     // Minimum threshold for type eval logging.
     typeEvaluationTimeThreshold = 50;
 
+    // Override default timeout (in seconds) for file enumeration operations.
+    fileEnumerationTimeoutInSec?: number;
+
+    // Override minimum number of files to visit before showing warning.
+    fileEnumerationMinimumFiles?: number;
+
     // Run ambient analysis.
     enableAmbientAnalysis = true;
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1451,10 +1451,6 @@ export class ConfigOptions {
     // Default is 10 seconds. Set to 0 to disable timeout warnings.
     fileEnumerationTimeoutInSec?: number;
 
-    // If specified, overrides the minimum number of files that need to be visited
-    // before showing a "slow enumeration" warning. Default is 50 files.
-    fileEnumerationMinimumFiles?: number;
-
     constructor(projectRoot: Uri) {
         this.projectRoot = projectRoot;
         this.diagnosticRuleSet = this.constructor.getDiagnosticRuleSet();

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1447,6 +1447,14 @@ export class ConfigOptions {
     // https://github.com/microsoft/TypeScript/issues/3841
     declare ['constructor']: typeof ConfigOptions;
 
+    // If specified, overrides the default timeout (in seconds) for file enumeration operations.
+    // Default is 10 seconds. Set to 0 to disable timeout warnings.
+    fileEnumerationTimeoutInSec?: number;
+
+    // If specified, overrides the minimum number of files that need to be visited
+    // before showing a "slow enumeration" warning. Default is 50 files.
+    fileEnumerationMinimumFiles?: number;
+
     constructor(projectRoot: Uri) {
         this.projectRoot = projectRoot;
         this.diagnosticRuleSet = this.constructor.getDiagnosticRuleSet();

--- a/packages/pyright-internal/src/common/languageServerInterface.ts
+++ b/packages/pyright-internal/src/common/languageServerInterface.ts
@@ -43,7 +43,6 @@ export interface ServerSettings {
     logTypeEvaluationTime?: boolean | undefined;
     typeEvaluationTimeThreshold?: number | undefined;
     fileEnumerationTimeoutInSec?: number | undefined;
-    fileEnumerationMinimumFiles?: number | undefined;
     includeFileSpecs?: string[];
     excludeFileSpecs?: string[];
     ignoreFileSpecs?: string[];

--- a/packages/pyright-internal/src/common/languageServerInterface.ts
+++ b/packages/pyright-internal/src/common/languageServerInterface.ts
@@ -42,6 +42,8 @@ export interface ServerSettings {
     indexing?: boolean | undefined;
     logTypeEvaluationTime?: boolean | undefined;
     typeEvaluationTimeThreshold?: number | undefined;
+    fileEnumerationTimeoutInSec?: number | undefined;
+    fileEnumerationMinimumFiles?: number | undefined;
     includeFileSpecs?: string[];
     excludeFileSpecs?: string[];
     ignoreFileSpecs?: string[];

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -386,6 +386,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             workspace.disableOrganizeImports = !!serverSettings.disableOrganizeImports;
             workspace.inlayHints = serverSettings.inlayHints;
             workspace.useTypingExtensions = serverSettings.useTypingExtensions ?? false;
+            workspace.fileEnumerationTimeoutInSec = serverSettings.fileEnumerationTimeoutInSec ?? 10;
         } finally {
             // Don't use workspace.isInitialized directly since it might have been
             // reset due to pending config change event.

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -148,6 +148,11 @@ function getEffectiveCommandLineOptions(
         commandLineOptions.configSettings.verboseOutput = true;
     }
 
+    if (serverSettings.fileEnumerationTimeoutInSec) {
+        commandLineOptions.languageServerSettings.fileEnumerationTimeoutInSec =
+            serverSettings.fileEnumerationTimeoutInSec;
+    }
+
     if (typeStubTargetImportName) {
         commandLineOptions.languageServerSettings.typeStubTargetImportName = typeStubTargetImportName;
     }

--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -217,6 +217,14 @@ export abstract class RealLanguageServer extends LanguageServerBase {
                     serverSettings.typeEvaluationTimeThreshold = pythonAnalysisSection.typeEvaluationTimeThreshold;
                 }
 
+                if (pythonAnalysisSection.fileEnumerationTimeout !== undefined) {
+                    serverSettings.fileEnumerationTimeoutInSec = pythonAnalysisSection.fileEnumerationTimeout;
+                }
+
+                if (pythonAnalysisSection.fileEnumerationMinimumFiles !== undefined) {
+                    serverSettings.fileEnumerationMinimumFiles = pythonAnalysisSection.fileEnumerationMinimumFiles;
+                }
+
                 const inlayHintSection = pythonAnalysisSection.inlayHints;
                 if (inlayHintSection) {
                     serverSettings.inlayHints = { ...serverSettings.inlayHints, ...inlayHintSection };

--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -221,10 +221,6 @@ export abstract class RealLanguageServer extends LanguageServerBase {
                     serverSettings.fileEnumerationTimeoutInSec = pythonAnalysisSection.fileEnumerationTimeout;
                 }
 
-                if (pythonAnalysisSection.fileEnumerationMinimumFiles !== undefined) {
-                    serverSettings.fileEnumerationMinimumFiles = pythonAnalysisSection.fileEnumerationMinimumFiles;
-                }
-
                 const inlayHintSection = pythonAnalysisSection.inlayHints;
                 if (inlayHintSection) {
                     serverSettings.inlayHints = { ...serverSettings.inlayHints, ...inlayHintSection };

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -637,6 +637,7 @@ describe(`config test'}`, () => {
         commandLineOptions.languageServerSettings.checkOnlyOpenFiles = true;
         commandLineOptions.languageServerSettings.disableTaggedHints = true;
         commandLineOptions.languageServerSettings.pythonPath = 'test_python_path';
+        commandLineOptions.languageServerSettings.fileEnumerationTimeoutInSec = 10;
 
         service.setOptions(commandLineOptions);
         let options = service.test_getConfigOptions(commandLineOptions);
@@ -646,6 +647,7 @@ describe(`config test'}`, () => {
         assert.strictEqual(options.logTypeEvaluationTime, true);
         assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
         assert.strictEqual(options.disableTaggedHints, true);
+        assert.strictEqual(options.fileEnumerationTimeoutInSec, 10);
         assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
 
         // Test with language server set to true to make sure they are still set.
@@ -659,6 +661,7 @@ describe(`config test'}`, () => {
         assert.strictEqual(options.logTypeEvaluationTime, true);
         assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
         assert.strictEqual(options.disableTaggedHints, true);
+        assert.strictEqual(options.fileEnumerationTimeoutInSec, 10);
         assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
 
         // Verify language server options don't override the config setting. Only command line should

--- a/packages/pyright-internal/src/tests/envVarUtils.test.ts
+++ b/packages/pyright-internal/src/tests/envVarUtils.test.ts
@@ -224,5 +224,6 @@ function createWorkspace(rootUri: Uri | undefined): Workspace {
         isInitialized: createInitStatus(),
         searchPathsToWatch: [],
         useTypingExtensions: false,
+        fileEnumerationTimeoutInSec: 10,
     };
 }

--- a/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
@@ -111,6 +111,7 @@ export class TestLanguageService implements LanguageServerInterface {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
     }
     /** unlike the real one, this test implementation doesn't support notebook cells. TODO: language server tests for notebook cells */

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -212,6 +212,7 @@ export class TestState {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
 
         if (!delayFileInitialization) {

--- a/packages/pyright-internal/src/workspaceFactory.ts
+++ b/packages/pyright-internal/src/workspaceFactory.ts
@@ -100,6 +100,7 @@ export interface Workspace extends WorkspaceFolder {
     searchPathsToWatch: Uri[];
     inlayHints?: InlayHintSettings | undefined;
     useTypingExtensions: boolean;
+    fileEnumerationTimeoutInSec: number;
 }
 
 export interface NormalWorkspace extends Workspace {
@@ -288,6 +289,7 @@ export class WorkspaceFactory {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
 
         // Stick in our map

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1763,6 +1763,18 @@
                         }
                     }
                 },
+                "basedpyright.analysis.fileEnumerationMinimumFiles": {
+                    "type": "integer",
+                    "default": 50,
+                    "description": "Minimum number of files that need to be visited before showing a 'slow enumeration' warning. Increase this value to reduce warnings in large workspaces.",
+                    "scope": "resource"
+                },
+                "basedpyright.analysis.fileEnumerationTimeout": {
+                    "type": "integer",
+                    "default": 10,
+                    "description": "Timeout (in seconds) for file enumeration operations. Set to 0 to disable the warning. Increase this value if your workspace is large.",
+                    "scope": "resource"
+                },
                 "basedpyright.analysis.logLevel": {
                     "type": "string",
                     "default": "Information",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1772,7 +1772,7 @@
                 "basedpyright.analysis.fileEnumerationTimeout": {
                     "type": "integer",
                     "default": 10,
-                    "description": "Timeout (in seconds) for file enumeration operations. Set to 0 to disable the warning. Increase this value if your workspace is large.",
+                    "description": "Timeout (in seconds) for file enumeration operations. Set to 0 to disable the warning.",
                     "scope": "resource"
                 },
                 "basedpyright.analysis.logLevel": {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1763,12 +1763,6 @@
                         }
                     }
                 },
-                "basedpyright.analysis.fileEnumerationMinimumFiles": {
-                    "type": "integer",
-                    "default": 50,
-                    "description": "Minimum number of files that need to be visited before showing a 'slow enumeration' warning. Increase this value to reduce warnings in large workspaces.",
-                    "scope": "resource"
-                },
                 "basedpyright.analysis.fileEnumerationTimeout": {
                     "type": "integer",
                     "default": 10,


### PR DESCRIPTION
## Description

This PR adds two new configuration options to improve the user experience with large workspaces:

* `basedpyright.analysis.fileEnumerationTimeout`: Controls when to show a "slow enumeration" warning (in seconds). Default is 10 seconds. Setting to 0 disables the warning completely.

These settings help users customize warnings based on their hardware capabilities and workspace size. Users with powerful machines can increase the timeout to reduce unnecessary warnings, while users with very large codebases can increase the minimum file count to prevent warnings in expected scenarios.

## Testing

* I conducted my testing using extension deveopment host (using provided debugging profile - Pyright extension (watch)

## TODO

- [x] Add doc changes
- [x] Update tests
- [ ] Add any schema changes to pyright json?