### PR TITLE
Add configurable file enumeration timeout settings

### DIFF
--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -46,8 +46,6 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownVariableType`](#reportUnknownVariableType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
-- <a name="fileEnumerationTimeoutInSec"></a> **fileEnumerationTimeoutInSec** [integer, optional]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely.
-
 ## Type Evaluation Settings
 
 The following settings determine how different types should be evaluated.

--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -46,6 +46,8 @@ The following settings control the *environment* in which basedpyright will chec
 
 - <a name="allowedUntypedLibraries"></a> **allowedUntypedLibraries** [array of strings, optional]: Suppress issues related to unknown types when functions and classes are imported from certain modules. This affects the rules [`reportUnknownVariableType`](#reportUnknownVariableType), [`reportUnknownMemberType`](#reportUnknownMemberType), and [`reportMissingTypeStubs`](#reportMissingTypeStubs). The option name should be a list of module names, for example, `["library", "module.submodule"]`. By default, no modules are configured.
 
+- <a name="fileEnumerationTimeoutInSec"></a> **fileEnumerationTimeoutInSec** [integer, optional]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely.
+
 ## Type Evaluation Settings
 
 The following settings determine how different types should be evaluated.

--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -57,7 +57,7 @@ the following settings are exclusive to basedpyright
 
 **basedpyright.analysis.useTypingExtensions** [boolean]: Whether to rely on imports from the `typing_extensions` module when targeting older versions of python that do not include certain typing features such as the `@override` decorator. Defaults to `false`. [more info](../benefits-over-pyright/language-server-improvements.md#autocomplete-improvements)
 
-**basedpyright.analysis.fileEnumerationTimeout** [integer]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely. Increase this value if you have a large workspace and don't want to see the warning.
+**basedpyright.analysis.fileEnumerationTimeout** [integer]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in some workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds.
 
 ### discouraged settings
 

--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -57,6 +57,8 @@ the following settings are exclusive to basedpyright
 
 **basedpyright.analysis.useTypingExtensions** [boolean]: Whether to rely on imports from the `typing_extensions` module when targeting older versions of python that do not include certain typing features such as the `@override` decorator. Defaults to `false`. [more info](../benefits-over-pyright/language-server-improvements.md#autocomplete-improvements)
 
+**basedpyright.analysis.fileEnumerationTimeout** [integer]: Timeout (in seconds) for file enumeration operations. When basedpyright scans your workspace files, it can take a long time in large workspaces. This setting controls when to show a "slow enumeration" warning. Default is 10 seconds. Set to 0 to disable the warning completely. Increase this value if you have a large workspace and don't want to see the warning.
+
 ### discouraged settings
 
 these options can also be configured [using a config file](./config-files.md). it's recommended to use either a `pyproject.toml` or `pyrightconfig.json` file instead of the language server to configure type checking for the following reasons:

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -918,6 +918,10 @@ export class AnalyzerService {
         }
         configOptions.typeEvaluationTimeThreshold = languageServerOptions.typeEvaluationTimeThreshold;
 
+        if (languageServerOptions.fileEnumerationTimeoutInSec !== undefined) {
+            configOptions.fileEnumerationTimeoutInSec = languageServerOptions.fileEnumerationTimeoutInSec;
+        }
+
         // Special case, the language service can also set a pythonPath. It should override any other setting.
         if (languageServerOptions.pythonPath) {
             this._console.info(
@@ -1374,7 +1378,10 @@ export class AnalyzerService {
         const envMarkers = [['bin', 'activate'], ['Scripts', 'activate'], ['pyvenv.cfg'], ['conda-meta']];
         const results: Uri[] = [];
         const startTime = Date.now();
-        const longOperationLimitInSec = 10;
+        const longOperationLimitInSec =
+            this._configOptions.fileEnumerationTimeoutInSec === undefined
+                ? 10
+                : this._configOptions.fileEnumerationTimeoutInSec;
         const nFilesToSuggestSubfolder = 50;
 
         let loggedLongOperationError = false;

--- a/packages/pyright-internal/src/common/commandLineOptions.ts
+++ b/packages/pyright-internal/src/common/commandLineOptions.ts
@@ -138,6 +138,9 @@ export class CommandLineLanguageServerOptions {
     // Minimum threshold for type eval logging.
     typeEvaluationTimeThreshold = 50;
 
+    // Override default timeout (in seconds) for file enumeration operations.
+    fileEnumerationTimeoutInSec?: number;
+
     // Run ambient analysis.
     enableAmbientAnalysis = true;
 

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1444,6 +1444,9 @@ export class ConfigOptions {
     // Determines the effective default type checking mode.
     effectiveTypeCheckingMode: TypeCheckingMode = 'standard'; // TODO: we default to "recommended", wheres this default being used?
 
+    // Overrides the default timeout for file enumeration operations.
+    fileEnumerationTimeoutInSec?: number;
+
     // https://github.com/microsoft/TypeScript/issues/3841
     declare ['constructor']: typeof ConfigOptions;
 

--- a/packages/pyright-internal/src/common/languageServerInterface.ts
+++ b/packages/pyright-internal/src/common/languageServerInterface.ts
@@ -49,6 +49,8 @@ export interface ServerSettings {
     functionSignatureDisplay?: SignatureDisplayType | undefined;
     inlayHints?: InlayHintSettings;
     useTypingExtensions?: boolean;
+
+    fileEnumerationTimeoutInSec?: number | undefined;
 }
 
 export interface MessageAction {

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -386,6 +386,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             workspace.disableOrganizeImports = !!serverSettings.disableOrganizeImports;
             workspace.inlayHints = serverSettings.inlayHints;
             workspace.useTypingExtensions = serverSettings.useTypingExtensions ?? false;
+            workspace.fileEnumerationTimeoutInSec = serverSettings.fileEnumerationTimeoutInSec ?? 10;
         } finally {
             // Don't use workspace.isInitialized directly since it might have been
             // reset due to pending config change event.

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -148,6 +148,11 @@ function getEffectiveCommandLineOptions(
         commandLineOptions.configSettings.verboseOutput = true;
     }
 
+    if (serverSettings.fileEnumerationTimeoutInSec) {
+        commandLineOptions.languageServerSettings.fileEnumerationTimeoutInSec =
+            serverSettings.fileEnumerationTimeoutInSec;
+    }
+
     if (typeStubTargetImportName) {
         commandLineOptions.languageServerSettings.typeStubTargetImportName = typeStubTargetImportName;
     }

--- a/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
+++ b/packages/pyright-internal/src/languageService/analyzerServiceExecutor.ts
@@ -148,7 +148,7 @@ function getEffectiveCommandLineOptions(
         commandLineOptions.configSettings.verboseOutput = true;
     }
 
-    if (serverSettings.fileEnumerationTimeoutInSec) {
+    if (serverSettings.fileEnumerationTimeoutInSec !== undefined) {
         commandLineOptions.languageServerSettings.fileEnumerationTimeoutInSec =
             serverSettings.fileEnumerationTimeoutInSec;
     }

--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -217,6 +217,10 @@ export abstract class RealLanguageServer extends LanguageServerBase {
                     serverSettings.typeEvaluationTimeThreshold = pythonAnalysisSection.typeEvaluationTimeThreshold;
                 }
 
+                if (pythonAnalysisSection.fileEnumerationTimeout !== undefined) {
+                    serverSettings.fileEnumerationTimeoutInSec = pythonAnalysisSection.fileEnumerationTimeout;
+                }
+
                 const inlayHintSection = pythonAnalysisSection.inlayHints;
                 if (inlayHintSection) {
                     serverSettings.inlayHints = { ...serverSettings.inlayHints, ...inlayHintSection };

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -637,6 +637,7 @@ describe(`config test'}`, () => {
         commandLineOptions.languageServerSettings.checkOnlyOpenFiles = true;
         commandLineOptions.languageServerSettings.disableTaggedHints = true;
         commandLineOptions.languageServerSettings.pythonPath = 'test_python_path';
+        commandLineOptions.languageServerSettings.fileEnumerationTimeoutInSec = 10;
 
         service.setOptions(commandLineOptions);
         let options = service.test_getConfigOptions(commandLineOptions);
@@ -647,6 +648,7 @@ describe(`config test'}`, () => {
         assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
         assert.strictEqual(options.disableTaggedHints, true);
         assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
+        assert.strictEqual(options.fileEnumerationTimeoutInSec, 10);
 
         // Test with language server set to true to make sure they are still set.
         commandLineOptions.fromLanguageServer = true;
@@ -660,6 +662,7 @@ describe(`config test'}`, () => {
         assert.strictEqual(options.typeEvaluationTimeThreshold, 1);
         assert.strictEqual(options.disableTaggedHints, true);
         assert.ok(options.pythonPath?.pathIncludes('test_python_path'));
+        assert.strictEqual(options.fileEnumerationTimeoutInSec, 10);
 
         // Verify language server options don't override the config setting. Only command line should
         assert.equal(options.venvPath?.pathIncludes('test_venv_path'), false);

--- a/packages/pyright-internal/src/tests/envVarUtils.test.ts
+++ b/packages/pyright-internal/src/tests/envVarUtils.test.ts
@@ -224,5 +224,6 @@ function createWorkspace(rootUri: Uri | undefined): Workspace {
         isInitialized: createInitStatus(),
         searchPathsToWatch: [],
         useTypingExtensions: false,
+        fileEnumerationTimeoutInSec: 10,
     };
 }

--- a/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testLanguageService.ts
@@ -111,6 +111,7 @@ export class TestLanguageService implements LanguageServerInterface {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
     }
     /** unlike the real one, this test implementation doesn't support notebook cells. TODO: language server tests for notebook cells */

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -212,6 +212,7 @@ export class TestState {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
 
         if (!delayFileInitialization) {

--- a/packages/pyright-internal/src/workspaceFactory.ts
+++ b/packages/pyright-internal/src/workspaceFactory.ts
@@ -100,6 +100,7 @@ export interface Workspace extends WorkspaceFolder {
     searchPathsToWatch: Uri[];
     inlayHints?: InlayHintSettings | undefined;
     useTypingExtensions: boolean;
+    fileEnumerationTimeoutInSec: number;
 }
 
 export interface NormalWorkspace extends Workspace {
@@ -288,6 +289,7 @@ export class WorkspaceFactory {
             isInitialized: createInitStatus(),
             searchPathsToWatch: [],
             useTypingExtensions: false,
+            fileEnumerationTimeoutInSec: 10,
         };
 
         // Stick in our map

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1763,6 +1763,12 @@
                         }
                     }
                 },
+                "basedpyright.analysis.fileEnumerationTimeout": {
+                    "type": "integer",
+                    "default": 10,
+                    "description": "Timeout (in seconds) for file enumeration operations. Set to 0 to disable the warning.",
+                    "scope": "resource"
+                },
                 "basedpyright.analysis.logLevel": {
                     "type": "string",
                     "default": "Information",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1766,7 +1766,7 @@
                 "basedpyright.analysis.fileEnumerationTimeout": {
                     "type": "integer",
                     "default": 10,
-                    "description": "Timeout (in seconds) for file enumeration operations. Set to 0 to disable the warning.",
+                    "description": "Timeout (in seconds) for file enumeration operations. Default is 10 seconds.",
                     "scope": "resource"
                 },
                 "basedpyright.analysis.logLevel": {


### PR DESCRIPTION
## Description

This PR introduces a configuration,

* `basedpyright.analysis.fileEnumerationTimeout`: Controls when to show a "slow enumeration" warning (in seconds). Default is 10 seconds. Setting to 0 disables the warning completely.

This setting is only applicable to the VS Code extension and only makes sense to enable it at the language server setting.

## Testing

* I conducted my testing using extension deveopment host (using provided debugging profile - Pyright extension (watch)

## TODO

- [x] Add doc changes
- [x] Update tests

fixes #1168