### PR TITLE
Allow .venv autodetection when config file missing

### DIFF
--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -711,14 +711,9 @@ export class AnalyzerService {
         // only apply to the language server.
         this._applyLanguageServerOptions(configOptions, projectRoot, commandLineOptions.languageServerSettings);
 
-        // If user didn't set either (venvPath & venv) or pythonPath, and project root is found,
+        // If user didn't set either (venvPath & venv) or pythonPath
         // try to fill pythonPath with a default value
-        if (
-            !configOptions.venvPath &&
-            !configOptions.venv &&
-            !configOptions.pythonPath &&
-            (configFilePath || pyprojectFilePath)
-        ) {
+        if (!configOptions.venvPath && !configOptions.venv && !configOptions.pythonPath) {
             // this is the most common name used for virtual environments, and newer tools like uv and pdm default to this name.
             // so if a python path hasn't been specified, we check whether a venv with this name exists in the project root.
             const defaultVenvPath = '.venv';


### PR DESCRIPTION
When no `pyproject.toml` or `pyrightconfig.json` file exists, the `pythonPath` is not automatically set to `.venv/bin/python` (if applicable). Creating an empty config file allows the autodetection to work again.

The cause is that the existence of a config file is explicitly checked - but a valid project root can be "found" without a config file, if the editor sent the correct workspace folders to the LSP. If the editor doesn't send any workspace folders, then the `projectRoot` is `/<default workspace root>`, which doesn't cause any issues and a venv just won't be detected.

This probably is only a problem outside of VS Code. An easy way to reproduce it is to take any project and just delete the `pyproject.toml` and `pyrightconfig.json` files, then open the project, without first activating the virtual environment in the terminal if using a terminal-based editor e.g. Neovim. Any imports for dependencies in the virtual environment should then start showing errors.