### PR TITLE
Add semantic highlights for `self` and `cls` parameters

### DIFF
--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -8,6 +8,7 @@ import {
     isClass,
     OverloadedType,
     Type,
+    TypeBase,
     TypeCategory,
     TypeFlags,
 } from './types';
@@ -27,8 +28,10 @@ import {
 } from '../parser/parseNodes';
 import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver';
 import { isConstantName } from './symbolNameUtils';
-import { CustomSemanticTokenModifiers } from '../languageService/semanticTokensProvider';
+import { CustomSemanticTokenModifiers, CustomSemanticTokenTypes } from '../languageService/semanticTokensProvider';
 import { isAliasDeclaration, isParamDeclaration } from './declaration';
+import { getScopeForNode } from './scopeUtils';
+import { ScopeType } from './scope';
 
 export type SemanticTokenItem = {
     type: string;
@@ -66,7 +69,10 @@ export class SemanticTokensWalker extends ParseTreeWalker {
 
     override visitParameter(node: ParameterNode): boolean {
         if (node.d.name) {
-            this._addItemForNameNode(node.d.name, SemanticTokenTypes.parameter, [SemanticTokenModifiers.definition]);
+            const type = this._evaluator?.getType(node.d.name);
+            this._addItemForNameNode(node.d.name, this._getParamSemanticToken(node, type), [
+                SemanticTokenModifiers.definition,
+            ]);
         }
         return super.visitParameter(node);
     }
@@ -238,10 +244,11 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         }
         const declarations = this._evaluator?.getDeclInfoForNameNode(node)?.decls;
         if (declarations?.some(isParamDeclaration)) {
-            const parent = declarations[0].node.parent as FunctionNode | LambdaNode;
+            const paramDef = declarations[0].node as ParameterNode;
+            const parent = paramDef.parent as FunctionNode | LambdaNode;
             // Avoid duplicates for parameters visited by `visitParameter`
             if (!parent.d.params.some((param) => param.d.name?.id === node.id)) {
-                this._addItemForNameNode(node, SemanticTokenTypes.parameter, []);
+                this._addItemForNameNode(node, this._getParamSemanticToken(paramDef, type), []);
             }
         } else if (type?.category === TypeCategory.TypeVar && !(type.flags & TypeFlags.Instance)) {
             // `cls` method parameter is treated as a TypeVar in some special methods (methods
@@ -259,6 +266,30 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         } else {
             this._addItemForNameNode(node, SemanticTokenTypes.variable, []);
         }
+    }
+
+    private _getParamSemanticToken(node: ParameterNode, type?: Type): string {
+        if (node.parent?.nodeType !== ParseNodeType.Function) {
+            return SemanticTokenTypes.parameter;
+        }
+        if (node.parent.d.params[0].id !== node.id) {
+            return SemanticTokenTypes.parameter;
+        }
+
+        const parentType = this._evaluator?.getType(node.parent.d.name);
+        const isMethodParam =
+            parentType?.category === TypeCategory.Function &&
+            (FunctionType.isClassMethod(parentType) ||
+                FunctionType.isInstanceMethod(parentType) ||
+                FunctionType.isConstructorMethod(parentType));
+
+        if (!(isMethodParam && getScopeForNode(node)?.type === ScopeType.Class)) {
+            return SemanticTokenTypes.parameter;
+        }
+
+        return type?.flags && TypeBase.isInstantiable(type)
+            ? CustomSemanticTokenTypes.clsParameter
+            : CustomSemanticTokenTypes.selfParameter;
     }
 
     private _addItemForNameNode = (node: NameNode, type: string, modifiers: string[]) =>

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -12,6 +12,11 @@ import { Uri } from '../common/uri/uri';
 import { ParseFileResults } from '../parser/parser';
 import { SemanticTokensWalker } from '../analyzer/semanticTokensWalker';
 
+export enum CustomSemanticTokenTypes {
+    selfParameter = 'selfParameter',
+    clsParameter = 'clsParameter',
+}
+
 export enum CustomSemanticTokenModifiers {
     builtin = 'builtin', // parity with pylance
 }
@@ -28,7 +33,10 @@ export const tokenTypes: string[] = [
     SemanticTokenTypes.variable,
     SemanticTokenTypes.type,
     SemanticTokenTypes.keyword,
+    CustomSemanticTokenTypes.selfParameter,
+    CustomSemanticTokenTypes.clsParameter,
 ];
+
 export const tokenModifiers: string[] = [
     SemanticTokenModifiers.definition,
     SemanticTokenModifiers.declaration,

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -55,20 +55,20 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'decorator', modifiers: [], start: 85, length: 1 },
             { type: 'decorator', modifiers: [], start: 86, length: 8 },
             { type: 'method', modifiers: [], start: 103, length: 3 },
-            { type: 'parameter', modifiers: ['definition'], start: 107, length: 4 },
+            { type: 'selfParameter', modifiers: ['definition'], start: 107, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 116, length: 3 },
             { type: 'method', modifiers: ['definition'], start: 148, length: 3 },
             { type: 'decorator', modifiers: [], start: 130, length: 1 },
             { type: 'decorator', modifiers: [], start: 131, length: 8 },
             { type: 'method', modifiers: [], start: 148, length: 3 },
-            { type: 'parameter', modifiers: ['definition'], start: 152, length: 4 },
+            { type: 'selfParameter', modifiers: ['definition'], start: 152, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 161, length: 3 },
             { type: 'method', modifiers: ['definition'], start: 194, length: 3 },
             { type: 'decorator', modifiers: [], start: 174, length: 1 },
             { type: 'variable', modifiers: [], start: 175, length: 3 },
             { type: 'function', modifiers: [], start: 179, length: 6 },
             { type: 'method', modifiers: [], start: 194, length: 3 },
-            { type: 'parameter', modifiers: ['definition'], start: 198, length: 4 },
+            { type: 'selfParameter', modifiers: ['definition'], start: 198, length: 4 },
             { type: 'parameter', modifiers: ['definition'], start: 204, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 211, length: 3 },
             { type: 'variable', modifiers: ['readonly'], start: 229, length: 3 },
@@ -237,7 +237,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'decorator', modifiers: [], start: 161, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 162, length: 5 }, // final
             { type: 'method', modifiers: [], start: 176, length: 6 },
-            { type: 'parameter', modifiers: ['definition'], start: 183, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['definition'], start: 183, length: 4 }, // self
             { type: 'method', modifiers: ['definition'], start: 220, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 198, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 199, length: 12 },
@@ -259,17 +259,17 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: [], start: 6, length: 1 },
             { type: 'method', modifiers: ['definition'], start: 17, length: 8 }, // __init__
             { type: 'method', modifiers: [], start: 17, length: 8 },
-            { type: 'parameter', modifiers: ['definition'], start: 26, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['definition'], start: 26, length: 4 }, // self
             { type: 'parameter', modifiers: ['definition'], start: 32, length: 1 }, // x
-            { type: 'parameter', modifiers: [], start: 44, length: 4 }, // self
+            { type: 'selfParameter', modifiers: [], start: 44, length: 4 }, // self
             { type: 'variable', modifiers: [], start: 49, length: 1 }, // x
             { type: 'parameter', modifiers: [], start: 53, length: 1 }, // x
             { type: 'method', modifiers: ['definition'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 61, length: 11 },
             { type: 'method', modifiers: [], start: 81, length: 1 },
-            { type: 'parameter', modifiers: ['definition'], start: 83, length: 3 }, // cls
-            { type: 'parameter', modifiers: [], start: 104, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['definition'], start: 83, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: [], start: 104, length: 3 }, // cls
             // function
             { type: 'function', modifiers: ['definition'], start: 116, length: 1 }, // f
             { type: 'function', modifiers: [], start: 116, length: 1 },


### PR DESCRIPTION
Fix #884

For `_getParamSemanticToken`, I adapted [this snippet](https://github.com/DetachHead/basedpyright/blob/0e751de8183ed305969274abaa323e4c75a2cd38/packages/pyright-internal/src/analyzer/packageTypeVerifier.ts#L1005-L1013) for detecting these special parameters in a more general way.