### PR TITLE
configure vscode to treat `selfParameter` and `clsParameter` semantic token types as a subtype of `parameter`

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -42,6 +42,18 @@
                 ]
             }
         ],
+        "semanticTokenTypes": [
+            {
+                "id": "selfParameter",
+                "description": "self parameter",
+                "superType": "parameter"
+            },
+            {
+                "id": "clsParameter",
+                "description": "cls parameter",
+                "superType": "parameter"
+            }
+        ],
         "commands": [
             {
                 "command": "basedpyright.organizeimports",


### PR DESCRIPTION
fyi @ValdezFOmar i noticed that although both pylance and basedpyright now use the custom `selfParameter` and `clsParameter` semantic token types, the highlighting was still different in vscode:

pylance:

![image](https://github.com/user-attachments/assets/3fdec84c-5a43-407d-bfb5-98ac95d93c65)

basedpyright:

![image](https://github.com/user-attachments/assets/0b582167-d084-496d-b1d8-83fc71e4aab5)

turns out we can tell vscode to treat these custom semantic token types like `parameter` by default, while still allowing the user to customize them. i'm pretty sure this is what pylance does.