### PR TITLE
fix(ipynb): skip parsing jupyter nbformat <4 to match vscode

### DIFF
--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -115,6 +115,13 @@ export const getIPythonCells = (fileSystem: FileSystem, uri: Uri, console: Conso
     }
     try {
         const parsedNotebook = JSON.parse(fileContent) as INotebookContent;
+
+        // https://github.com/microsoft/vscode/blob/7e4e0f4e55d0d0a2a931aa4e0b7acc518e5da0dd/extensions/ipynb/src/notebookSerializer.ts#L49
+        // VSCode does not support jupyter nbformat 3 since 1.63.0
+        if (parsedNotebook.nbformat && parsedNotebook.nbformat < 4) {
+            return;
+        }
+
         return parsedNotebook.cells.filter(
             (cell) =>
                 cell.cell_type === 'code' &&


### PR DESCRIPTION
When I open a folder, I see:
![CleanShot 2025-06-13 at 12 04 36@2x](https://github.com/user-attachments/assets/fbf407bb-ba4d-4511-aaca-18d7004796ab)

because the `.ipynb` file is `nbformat: 3`:
![CleanShot 2025-06-13 at 12 06 00@2x](https://github.com/user-attachments/assets/8d7575f9-ab4b-4aa7-be04-42d8a39bee23)


VSCode dropped support for jupyter nbformat 3 since version 1.63.0. This change aligns pyright's behavior by skipping parsing of older notebook formats.
