### PR TITLE
fix crash in meovim caused by invalid annotation ID in WorkspaceEdit

### DIFF
--- a/packages/pyright-internal/src/common/workspaceEditUtils.ts
+++ b/packages/pyright-internal/src/common/workspaceEditUtils.ts
@@ -276,7 +276,7 @@ function _convertToWorkspaceEditWithDocumentChanges(
                     value.map((v) => ({
                         range: v.range,
                         newText: v.replacementText,
-                        annotationId: defaultAnnotationId,
+                        annotationId: changeAnnotations !== undefined ? defaultAnnotationId : undefined,
                     }))
                 )
             )

--- a/packages/pyright-internal/src/languageService/renameProvider.ts
+++ b/packages/pyright-internal/src/languageService/renameProvider.ts
@@ -7,7 +7,7 @@
  * Logic that rename identifier on the given position and its references.
  */
 
-import { CancellationToken, ChangeAnnotation, WorkspaceEdit } from 'vscode-languageserver';
+import { CancellationToken, WorkspaceEdit } from 'vscode-languageserver';
 
 import { isUserCode } from '../analyzer/sourceFileInfoUtils';
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
@@ -154,16 +154,7 @@ export class RenameProvider {
             });
         });
 
-        const symbolNames = this._getRenameSymbolNames(referencesResult.symbolNames) ?? 'symbol';
-        return convertToWorkspaceEdit(
-            this._ls,
-            this._program.fileSystem,
-            { edits, fileOperations: [] },
-            {
-                rename_symbol: ChangeAnnotation.create('Rename', false, `Rename ${symbolNames} to ${newName}`),
-            },
-            'rename_symbol'
-        );
+        return convertToWorkspaceEdit(this._ls, this._program.fileSystem, { edits, fileOperations: [] });
     }
 
     static getRenameSymbolMode(
@@ -237,15 +228,5 @@ export class RenameProvider {
             referencesResult.useCase,
             referencesResult.providers
         );
-    }
-
-    private _getRenameSymbolNames(names: string[]): string | null {
-        if (names.length === 1) {
-            return names[0];
-        } else if (names.length > 1) {
-            return names.slice(0, -1).join(', ') + ' and ' + names[names.length - 1];
-        } else {
-            return null;
-        }
     }
 }


### PR DESCRIPTION
Neovim currently reports an error that annotations are missing for the edit when trying to rename symbols.