### PR TITLE
cli `--threads` should throw error if non integer or 'auto' value is passed

### DIFF
--- a/packages/pyright-internal/src/pyright.ts
+++ b/packages/pyright-internal/src/pyright.ts
@@ -1523,7 +1523,7 @@ function parseThreadsArgValue(input: string | null): any {
 
     const value = parseInt(input, 10);
     if (isNaN(value) || value < 1) {
-        return null;
+        throw new Error(`'${input}' is not a valid value for --threads; specify a positive integer or 'auto'`);
     }
 
     return value;


### PR DESCRIPTION
### Context
`--threads` currently takes in a null value and silently disregards it. This PR rectifies that and throws an error.

<img width="730" alt="Screenshot 2025-06-27 at 12 14 51 pm" src="https://github.com/user-attachments/assets/04a20f6e-36e4-4e59-93b3-7e6ef7c4c967" />

fixes #688
