### PR TITLE
Fix contravariant TypeVar example in documentation

### DIFF
--- a/docs/benefits-over-pyright/improved-generic-narrowing.md
+++ b/docs/benefits-over-pyright/improved-generic-narrowing.md
@@ -47,7 +47,8 @@ def foo(value: object):
 when a type variable is contravariant its widest possible type is `Never`, so when `strictGenericNarrowing` is enabled, contravariant generics get narrowed to `Never` instead of "Unknown":
 
 ```py
-T_contra = TypeVar("T_contra", bound=int | str, covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
 
 class Foo(Generic[T_contra]):
     ...


### PR DESCRIPTION
This PR fixes a documentation error in the "Narrowing of Contravariant Generics" section.

Previously:
T_contra = TypeVar("T_contra", bound=int | str, covariant=True)

This was likely a copy-paste error from the covariant example. Now corrected to:
T_contra = TypeVar("T_contra", contravariant=True)