### PR TITLE
Document installation on Neovim 0.11+

### DIFF
--- a/docs/installation/ides.md
+++ b/docs/installation/ides.md
@@ -83,6 +83,14 @@ adapter for native Neovim's LSP support.
 After having both, the client-side plugin and the LSP server command installed,
 simply add this settings to your Neovim's settings:
 
+For Neovim 0.11+
+
+```lua
+vim.lsp.enable("basedpyright")
+```
+
+For Neovim 0.10 (legacy)
+
 ```lua
 local lspconfig = require("lspconfig")
 lspconfig.basedpyright.setup{}


### PR DESCRIPTION
Hello,

I just replaced `pyright` with `basedpyright` on my Neovim config, and I noticed the documentation uses the legacy installation method of Neovim <=0.10.

As per `nvim-lspconfig` [documentation](https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#quickstart), Neovim 0.11+ uses another way to enable lsp servers i.e.

```lua
vim.lsp.enable('basepyright')
```