### PR TITLE
fix `writeBaseline`, `restartServer` and `createTypeStub` commands only being registered in the vscode extension instead of the language server

### DIFF
--- a/packages/pyright-internal/src/realLanguageServer.ts
+++ b/packages/pyright-internal/src/realLanguageServer.ts
@@ -43,6 +43,7 @@ import { CancellationProvider } from './common/cancellationUtils';
 import { FileWatcherHandler } from './common/fileWatcher';
 import version from './version.json';
 import { PartialStubService } from './partialStubService';
+import { Commands } from './commands/commands';
 
 const maxAnalysisTimeInForeground = { openFilesTimeInMs: 50, noOpenFilesTimeInMs: 200 };
 
@@ -97,6 +98,9 @@ export abstract class RealLanguageServer extends LanguageServerBase {
                 fileWatcherHandler: fileWatcherProvider,
                 maxAnalysisTimeInForeground,
                 supportedCodeActions: [CodeActionKind.QuickFix, CodeActionKind.SourceOrganizeImports],
+                // TODO: all the other commands are registered in the vscode extension because they seem to have client side logic
+                // for some reason
+                supportedCommands: [Commands.createTypeStub, Commands.restartServer, Commands.writeBaseline],
             },
             connection
         );

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -297,15 +297,6 @@ export async function activate(context: ExtensionContext) {
         );
     });
 
-    const genericCommands = [Commands.createTypeStub, Commands.restartServer, Commands.writeBaseline];
-    genericCommands.forEach((command) => {
-        context.subscriptions.push(
-            commands.registerCommand(command, (...args: any[]) => {
-                client.sendRequest('workspace/executeCommand', { command, arguments: args });
-            })
-        );
-    });
-
     // Register the debug only commands when running under the debugger.
     if (context.extensionMode === ExtensionMode.Development) {
         // Create a 'when' context for development.


### PR DESCRIPTION
fixes #1381