### PR TITLE
Remove duplicate semantic tokens for readonly properties

### DIFF
--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -1,15 +1,6 @@
 import { ParseTreeWalker } from './parseTreeWalker';
 import { TypeEvaluator } from './typeEvaluatorTypes';
-import {
-    ClassType,
-    FunctionType,
-    getTypeAliasInfo,
-    isClass,
-    OverloadedType,
-    Type,
-    TypeBase,
-    TypeCategory,
-} from './types';
+import { ClassType, FunctionType, getTypeAliasInfo, OverloadedType, Type, TypeBase, TypeCategory } from './types';
 import {
     ClassNode,
     DecoratorNode,
@@ -17,7 +8,6 @@ import {
     ImportAsNode,
     ImportFromAsNode,
     ImportFromNode,
-    MemberAccessNode,
     NameNode,
     ParameterNode,
     ParseNodeType,
@@ -142,19 +132,6 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         // `def`, `class` and `lambda` which are blue but i can't figure out what semantic token type does that.
         this._addItem(node.start, 4 /* length of the word "type" */, SemanticTokenTypes.keyword, []);
         return super.visitTypeAlias(node);
-    }
-
-    override visitMemberAccess(node: MemberAccessNode): boolean {
-        // check for properties without a setter
-        if (node.parent && this._evaluator) {
-            const declaredType = this._evaluator.getDeclaredTypeForExpression(node, {
-                method: 'set',
-            });
-            if (declaredType && isClass(declaredType) && ClassType.isPropertyClass(declaredType)) {
-                this._addItemForNameNode(node.d.member, SemanticTokenTypes.variable, [SemanticTokenModifiers.readonly]);
-            }
-        }
-        return super.visitMemberAccess(node);
     }
 
     private _visitNameWithType(node: NameNode, type: Type) {

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -77,7 +77,6 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'selfParameter', modifiers: ['definition'], start: 198, length: 4 },
             { type: 'parameter', modifiers: ['definition'], start: 204, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 211, length: 3 },
-            { type: 'variable', modifiers: ['readonly'], start: 229, length: 3 },
             { type: 'class', modifiers: [], start: 223, length: 3 },
             { type: 'variable', modifiers: ['readonly'], start: 229, length: 3 },
             { type: 'class', modifiers: [], start: 233, length: 3 },
@@ -85,7 +84,6 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 244, length: 3 },
             { type: 'class', modifiers: [], start: 250, length: 3 },
             { type: 'variable', modifiers: [], start: 256, length: 1 },
-            { type: 'variable', modifiers: ['readonly'], start: 264, length: 3 },
             { type: 'variable', modifiers: [], start: 260, length: 3 },
             { type: 'variable', modifiers: ['readonly'], start: 264, length: 3 },
         ]);


### PR DESCRIPTION
I found that this method was creating duplicate tokens for properties without a setter since `visitNameWithType()` was already able to identify these properties as being readonly.