### PR TITLE
fix `# pyright: ignore` code actions inserting the comment before the last character if the error is on the last line in the file

### DIFF
--- a/packages/pyright-internal/src/languageService/codeActionProvider.ts
+++ b/packages/pyright-internal/src/languageService/codeActionProvider.ts
@@ -19,7 +19,12 @@ import { convertToFileTextEdits, convertToTextEditActions, convertToWorkspaceEdi
 import { Localizer } from '../localization/localize';
 import { Workspace } from '../workspaceFactory';
 import { CompletionProvider } from './completionProvider';
-import { convertOffsetToPosition, convertPositionToOffset, convertTextRangeToRange } from '../common/positionUtils';
+import {
+    convertOffsetToPosition,
+    convertPositionToOffset,
+    convertTextRangeToRange,
+    getLineEndPosition,
+} from '../common/positionUtils';
 import { findNodeByOffset } from '../analyzer/parseTreeUtils';
 import { ParseNodeType } from '../parser/parseNodes';
 import { sorter } from '../common/collectionUtils';
@@ -200,8 +205,7 @@ export class CodeActionProvider {
             }
             const ignoreCommentPrefix = `# pyright: ignore`;
             const line = diagnostic.range.start.line;
-            const item = lines.getItemAt(line);
-            // we deliberately only check for type:ignore comments here but not pyright:ignore for 2 reasons:
+            // we deliberately only check for pyright:ignore comments here but not type:ignore for 2 reasons:
             // - type:ignore comments are discouraged in favor of pyright:ignore comments
             // - the type:ignore comment might be for another type checker
             const existingIgnoreComment = parseResults.tokenizerOutput.pyrightIgnoreLines.get(line);
@@ -217,7 +221,7 @@ export class CodeActionProvider {
                 insertText = `, ${rule}`;
                 title = `Add \`${rule}\` to existing \`${ignoreCommentPrefix}\` comment`;
             } else {
-                positionCharacter = item.length - 1;
+                positionCharacter = getLineEndPosition(parseResults.tokenizerOutput, parseResults.text, line).character;
                 const ignoreComment = `${ignoreCommentPrefix}[${rule}]`;
                 insertText = `  ${ignoreComment}`;
                 title = `Add \`${ignoreComment}\``;

--- a/packages/pyright-internal/src/tests/fourslash/ignoreComments.invokeCodeAction.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/ignoreComments.invokeCodeAction.fourslash.ts
@@ -4,22 +4,27 @@
 //// {}
 
 // @filename: test.py
-//// 1 + ""[|/*marker1*/|]
-//// 1 + ""[|/*marker2*/|] # pyright:ignore[reportOperatorIssue[|/*marker3*/|] ]
+//// 1 + ""[|/*noExistingCommentMarker*/|]
+//// 1 + ""[|/*existingCommentMarker1*/|] # pyright:ignore[reportOperatorIssue[|/*existingCommentMarker2*/|] ]
+//// 1 + ""[|/*noExistingCommentAtEofMarker*/|]
 {
-    const marker1Range = helper.getPositionRange('marker1');
-    const marker3Range = helper.getPositionRange('marker3');
+    const noExistingCommentMarkerRange = helper.getPositionRange('noExistingCommentMarker');
+    const existingCommentMarker2 = helper.getPositionRange('existingCommentMarker2');
+    const noExistingCommentAtEofMarkerRange = helper.getPositionRange('noExistingCommentAtEofMarker');
 
     //@ts-expect-error https://github.com/DetachHead/basedpyright/issues/86
     await helper.verifyCodeActions('included', {
-        marker1: {
+        noExistingCommentMarker: {
             codeActions: [
                 {
                     title: 'Add `# pyright: ignore[reportOperatorIssue]`',
                     edit: {
                         changes: {
                             'file:///test.py': [
-                                { range: marker1Range, newText: '  # pyright: ignore[reportOperatorIssue]' },
+                                {
+                                    range: noExistingCommentMarkerRange,
+                                    newText: '  # pyright: ignore[reportOperatorIssue]',
+                                },
                             ],
                         },
                     },
@@ -27,13 +32,32 @@
                 },
             ],
         },
-        marker2: {
+        existingCommentMarker1: {
             codeActions: [
                 {
                     title: 'Add `reportUnusedExpression` to existing `# pyright: ignore` comment',
                     edit: {
                         changes: {
-                            'file:///test.py': [{ range: marker3Range, newText: ', reportUnusedExpression' }],
+                            'file:///test.py': [{ range: existingCommentMarker2, newText: ', reportUnusedExpression' }],
+                        },
+                    },
+                    kind: 'quickfix',
+                },
+            ],
+        },
+
+        noExistingCommentAtEofMarker: {
+            codeActions: [
+                {
+                    title: 'Add `# pyright: ignore[reportOperatorIssue]`',
+                    edit: {
+                        changes: {
+                            'file:///test.py': [
+                                {
+                                    range: noExistingCommentAtEofMarkerRange,
+                                    newText: '  # pyright: ignore[reportOperatorIssue]',
+                                },
+                            ],
                         },
                     },
                     kind: 'quickfix',


### PR DESCRIPTION
fixes #1396