### PR TITLE
Hide inlay hints when the parameter matches an accessed member's name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13967,7 +13967,7 @@
         },
         "packages/pyright": {
             "name": "basedpyright",
-            "version": "1.1.402",
+            "version": "1.1.403",
             "license": "MIT",
             "bin": {
                 "basedpyright": "index.js",
@@ -13993,7 +13993,7 @@
             }
         },
         "packages/pyright-internal": {
-            "version": "1.1.402",
+            "version": "1.1.403",
             "license": "MIT",
             "dependencies": {
                 "@actions/core": "^1.10.1",
@@ -14046,7 +14046,7 @@
             "dev": true
         },
         "packages/vscode-pyright": {
-            "version": "1.1.402",
+            "version": "1.1.403",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.5",
@@ -14057,7 +14057,7 @@
             },
             "devDependencies": {
                 "@types/node": "^22.10.5",
-                "@types/vscode": "^1.99.0",
+                "@types/vscode": "^1.100.0",
                 "@vscode/vsce": "^2.32.0",
                 "copy-webpack-plugin": "^11.0.0",
                 "esbuild-loader": "^3.2.0",
@@ -14069,7 +14069,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.99.0"
+                "vscode": "^1.100.0"
             }
         }
     }

--- a/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
+++ b/packages/pyright-internal/src/analyzer/typeInlayHintsWalker.ts
@@ -14,6 +14,9 @@ import {
     isTypeVar,
 } from '../analyzer/types';
 import { ProgramView } from '../common/extensibility';
+import { convertRangeToTextRange } from '../common/positionUtils';
+import { TextRange } from '../common/textRange';
+import { Uri } from '../common/uri/uri';
 import { limitOverloadBasedOnCall } from '../languageService/tooltipUtils';
 import {
     AssignmentNode,
@@ -26,14 +29,11 @@ import {
     ParseNodeType,
     TypeAnnotationNode,
 } from '../parser/parseNodes';
-import { isLiteralType } from './typeUtils';
-import { TextRange } from '../common/textRange';
-import { convertRangeToTextRange } from '../common/positionUtils';
-import { transformTypeForEnumMember } from './enums';
-import { InlayHintSettings } from '../workspaceFactory';
-import { ImportTracker, ImportTrackerResults } from './typePrinter';
-import { Uri } from '../common/uri/uri';
 import { ParseFileResults } from '../parser/parser';
+import { InlayHintSettings } from '../workspaceFactory';
+import { transformTypeForEnumMember } from './enums';
+import { ImportTracker, ImportTrackerResults } from './typePrinter';
+import { isLiteralType } from './typeUtils';
 
 export type TypeInlayHintsItemType = {
     inlayHintType: 'variable' | 'functionReturn' | 'parameter' | 'generic';
@@ -351,9 +351,9 @@ export class TypeInlayHintsWalker extends ParseTreeWalker {
                 continue;
             }
             if (
-                argNode.nodeType === ParseNodeType.Name &&
-                p.paramName === argNode.d.value &&
-                !this._settings.callArgumentNamesMatching
+                !this._settings.callArgumentNamesMatching &&
+                ((argNode.nodeType === ParseNodeType.Name && p.paramName === argNode.d.value) ||
+                    (argNode.nodeType === ParseNodeType.MemberAccess && p.paramName === argNode.d.member.d.value))
             ) {
                 continue;
             }

--- a/packages/pyright-internal/src/tests/samples/inlay_hints/method_calls.py
+++ b/packages/pyright-internal/src/tests/samples/inlay_hints/method_calls.py
@@ -1,0 +1,10 @@
+def bar(foo: int) -> None:
+    pass
+
+class Foo:
+    foo: int
+
+    def baz(self) -> None:
+        bar(3)
+        bar(self.foo)
+        bar(baz.quz.qux.foo)

--- a/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
+++ b/packages/pyright-internal/src/tests/typeInlayHintsWalker.test.ts
@@ -1,6 +1,6 @@
+import { tExpect } from 'typed-jest-expect';
 import { ImportTrackerResults } from '../analyzer/typePrinter';
 import { inlayHintSampleFile } from './testUtils';
-import { tExpect } from 'typed-jest-expect';
 
 const noImports: ImportTrackerResults = { imports: new Set(), importFroms: new Map() };
 
@@ -124,6 +124,23 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { inlayHintType: 'parameter', position: 460, value: 'a=' },
             { inlayHintType: 'parameter', position: 488, value: 'b=' },
             { inlayHintType: 'parameter', position: 711, value: 'b=' },
+        ]);
+    });
+
+    test('method calls', () => {
+        const result = inlayHintSampleFile('method_calls.py', undefined);
+        // With callArgumentNamesMatching false, member accesses ending in .foo should NOT show hint
+        // bar(3) shows hint, bar(self.foo) doesn't, bar(baz.quz.qux.foo) doesn't
+        tExpect(result).toStrictEqual([{ inlayHintType: 'parameter', position: 101, value: 'foo=' }]);
+    });
+
+    test('method calls param matching', () => {
+        const result = inlayHintSampleFile('method_calls.py', undefined, { callArgumentNamesMatching: true });
+        // With callArgumentNamesMatching true, all three calls should show hints
+        tExpect(result).toStrictEqual([
+            { inlayHintType: 'parameter', position: 101, value: 'foo=' },
+            { inlayHintType: 'parameter', position: 116, value: 'foo=' }, // this one is unique to callArgumentNamesMatching: true
+            { inlayHintType: 'parameter', position: 138, value: 'foo=' }, // this one is unique to callArgumentNamesMatching: true
         ]);
     });
 


### PR DESCRIPTION
This comes up a lot for me, for example

<img width="507" height="35" alt="image" src="https://github.com/user-attachments/assets/81fa71c9-6238-4bca-92b0-9f12739dbe85" />

So I expanded the matching to also hide the inlay hint when the names match, aside from a `self.` prefix.

After doing that, I realized `cls.` deserves similar treatment. But then I took it further and removed the left-side logic so that we hide it if the name matches regardless of the object it's coming from So even if it was `foo.bar.baz.qux`, we still don't show the `qux=` hint.

Also, VSCode automatically organized imports, which seemed harmless but I can revert if undesired.

### Testing
I wrote a test for both configurations as well as manually verified the behavior:
<img width="755" height="287" alt="image" src="https://github.com/user-attachments/assets/3beba975-fe5d-42e7-a808-ac98e760436a" />