### PR TITLE
fix: enable onTypeFormatting regardless of dynamicRegistration support

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -659,7 +659,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             !!capabilities.textDocument?.diagnostic?.relatedInformation &&
             initializationOptions?.diagnosticMode !== 'workspace' &&
             initializationOptions?.disablePullDiagnostics !== true;
-        this.client.onTypeFormatting = capabilities.textDocument?.onTypeFormatting?.dynamicRegistration ?? false;
+        this.client.onTypeFormatting = capabilities.textDocument?.onTypeFormatting !== undefined;
 
         // Create a service instance for each of the workspace folders.
         this.workspaceFactory.handleInitialize(params);


### PR DESCRIPTION
Currently, the server only responds to `onTypeFormatting` requests if clients support dynamic registration for `onTypeFormatting`. However, the server doesn't make use of dynamic registration for this method (or any, except didchangedwatchfiles, I think) capability, so this isn't necessary. We can enable the feature regardless of the client's support for `dynamicRegistration`.