### PR TITLE
Improved Semantic Tokens: Enums, Properties, Constants, and Static Methods

### DIFF
--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -431,9 +431,3 @@ export function resolveAliasDeclaration(
         alreadyVisited.push(curDeclaration);
     }
 }
-
-export function isMagicAttributeAccess(declaration: Declaration): boolean {
-    const isMethod = declaration.type === DeclarationType.Function && declaration.isMethod;
-    const name = getNameFromDeclaration(declaration);
-    return isMethod && name ? ['__getattribute__', '__getattr__', '__setattr__', '__delattr__'].includes(name) : false;
-}

--- a/packages/pyright-internal/src/analyzer/declarationUtils.ts
+++ b/packages/pyright-internal/src/analyzer/declarationUtils.ts
@@ -431,3 +431,9 @@ export function resolveAliasDeclaration(
         alreadyVisited.push(curDeclaration);
     }
 }
+
+export function isMagicAttributeAccess(declaration: Declaration): boolean {
+    const isMethod = declaration.type === DeclarationType.Function && declaration.isMethod;
+    const name = getNameFromDeclaration(declaration);
+    return isMethod && name ? ['__getattribute__', '__getattr__', '__setattr__', '__delattr__'].includes(name) : false;
+}

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -39,12 +39,12 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         super();
     }
     override visitClass(node: ClassNode): boolean {
-        this._addItemForNameNode(node.d.name, SemanticTokenTypes.class, [SemanticTokenModifiers.definition]);
+        this._addItemForNameNode(node.d.name, SemanticTokenTypes.class, [SemanticTokenModifiers.declaration]);
         return super.visitClass(node);
     }
 
     override visitFunction(node: FunctionNode): boolean {
-        const modifiers = [SemanticTokenModifiers.definition];
+        const modifiers = [SemanticTokenModifiers.declaration];
         if (node.d.isAsync) {
             modifiers.push(SemanticTokenModifiers.async);
         }
@@ -62,7 +62,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         if (node.d.name) {
             const type = this._evaluator.getType(node.d.name);
             this._addItemForNameNode(node.d.name, this._getParamSemanticToken(node, type), [
-                SemanticTokenModifiers.definition,
+                SemanticTokenModifiers.declaration,
             ]);
         }
         return super.visitParameter(node);

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -40,10 +40,11 @@ export const tokenTypes: string[] = [
 ];
 
 export const tokenModifiers: string[] = [
-    SemanticTokenModifiers.definition,
     SemanticTokenModifiers.declaration,
-    SemanticTokenModifiers.async,
+    SemanticTokenModifiers.definition,
     SemanticTokenModifiers.readonly,
+    SemanticTokenModifiers.static,
+    SemanticTokenModifiers.async,
     SemanticTokenModifiers.defaultLibrary,
     CustomSemanticTokenModifiers.builtin,
 ];

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -22,17 +22,19 @@ export enum CustomSemanticTokenModifiers {
 }
 
 export const tokenTypes: string[] = [
+    SemanticTokenTypes.namespace,
+    SemanticTokenTypes.type,
     SemanticTokenTypes.class,
-    SemanticTokenTypes.parameter,
+    SemanticTokenTypes.enum,
     SemanticTokenTypes.typeParameter,
+    SemanticTokenTypes.parameter,
+    SemanticTokenTypes.variable,
+    SemanticTokenTypes.property,
+    SemanticTokenTypes.enumMember,
     SemanticTokenTypes.function,
     SemanticTokenTypes.method,
-    SemanticTokenTypes.decorator,
-    SemanticTokenTypes.property,
-    SemanticTokenTypes.namespace,
-    SemanticTokenTypes.variable,
-    SemanticTokenTypes.type,
     SemanticTokenTypes.keyword,
+    SemanticTokenTypes.decorator,
     CustomSemanticTokenTypes.selfParameter,
     CustomSemanticTokenTypes.clsParameter,
 ];

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/decorators.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/decorators.py
@@ -1,7 +1,8 @@
 import dataclasses
-from dataclasses import dataclass
 import functools
+from dataclasses import dataclass
 from typing import final
+
 
 @dataclass()
 class A: ...
@@ -15,3 +16,5 @@ class B:
 
 @functools.cache
 def cached(): ...
+
+B.static()

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/enum.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/enum.py
@@ -1,0 +1,8 @@
+from enum import IntEnum
+
+
+class Enumeration(IntEnum):
+    yes = 1
+    no = 0
+
+a = Enumeration.yes

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/final.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/final.py
@@ -1,11 +1,16 @@
-from typing import Final
+from math import pi
+from typing import Final, override
 
 FOO = 1
 foo: Final = 2
 _ = 3
 __: Final = 4
 
+
 class Foo:
+    def __init__(self):
+        self.constant: Final = 42
+
     @property
     def foo(self) -> int: ...
 
@@ -14,9 +19,26 @@ class Foo:
     @foo.setter
     def bar(self, value: int): ...
 
+    def __getattr__(self, name: str) -> float:
+        return pi
+
+
+class Bar:
+    fir: Final[int] = 128
+
+    def __getattr__(self, name: str) -> int:
+        return int(name)
+
+    @override
+    def __setattr__(self, name: str, value: int):
+        pass
+
 
 Foo().foo
 Foo().bar
 
 baz = Foo()
 _ = baz.foo
+meaning = baz.constant
+bam = baz.pi + Bar.fir
+bar = Bar().beef

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -59,33 +59,33 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 49, length: 1 },
             { type: 'variable', modifiers: ['readonly'], start: 55, length: 2 },
             { type: 'class', modifiers: [], start: 59, length: 5 },
-            { type: 'class', modifiers: ['definition'], start: 76, length: 3 },
-            { type: 'method', modifiers: ['definition'], start: 103, length: 3 },
+            { type: 'class', modifiers: ['declaration'], start: 76, length: 3 },
+            { type: 'property', modifiers: ['declaration'], start: 103, length: 3 },
             { type: 'decorator', modifiers: [], start: 85, length: 1 },
             { type: 'decorator', modifiers: [], start: 86, length: 8 },
-            { type: 'selfParameter', modifiers: ['definition'], start: 107, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 107, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 116, length: 3 },
-            { type: 'method', modifiers: ['definition'], start: 148, length: 3 },
+            { type: 'property', modifiers: ['declaration'], start: 148, length: 3 },
             { type: 'decorator', modifiers: [], start: 130, length: 1 },
             { type: 'decorator', modifiers: [], start: 131, length: 8 },
-            { type: 'selfParameter', modifiers: ['definition'], start: 152, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 152, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 161, length: 3 },
-            { type: 'method', modifiers: ['definition'], start: 194, length: 3 },
+            { type: 'property', modifiers: ['declaration'], start: 194, length: 3 },
             { type: 'decorator', modifiers: [], start: 174, length: 1 },
-            { type: 'variable', modifiers: [], start: 175, length: 3 },
+            { type: 'property', modifiers: [], start: 175, length: 3 },
             { type: 'function', modifiers: [], start: 179, length: 6 },
-            { type: 'selfParameter', modifiers: ['definition'], start: 198, length: 4 },
-            { type: 'parameter', modifiers: ['definition'], start: 204, length: 5 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 198, length: 4 },
+            { type: 'parameter', modifiers: ['declaration'], start: 204, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 211, length: 3 },
             { type: 'class', modifiers: [], start: 223, length: 3 },
-            { type: 'variable', modifiers: ['readonly'], start: 229, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 229, length: 3 },
             { type: 'class', modifiers: [], start: 233, length: 3 },
-            { type: 'variable', modifiers: [], start: 239, length: 3 },
+            { type: 'property', modifiers: [], start: 239, length: 3 },
             { type: 'variable', modifiers: [], start: 244, length: 3 },
             { type: 'class', modifiers: [], start: 250, length: 3 },
             { type: 'variable', modifiers: [], start: 256, length: 1 },
             { type: 'variable', modifiers: [], start: 260, length: 3 },
-            { type: 'variable', modifiers: ['readonly'], start: 264, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 264, length: 3 },
         ]);
     });
 
@@ -98,10 +98,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'type', modifiers: [], start: 31, length: 5 }, // Never
             { type: 'type', modifiers: [], start: 37, length: 3 }, // bar
             { type: 'type', modifiers: [], start: 43, length: 5 }, // Never
-            { type: 'function', modifiers: ['definition'], start: 54, length: 3 }, // baz
+            { type: 'function', modifiers: ['declaration'], start: 54, length: 3 }, // baz
             { type: 'type', modifiers: [], start: 63, length: 5 }, // Never
-            { type: 'function', modifiers: ['definition'], start: 83, length: 4 }, // asdf
-            { type: 'parameter', modifiers: ['definition'], start: 88, length: 3 }, // foo
+            { type: 'function', modifiers: ['declaration'], start: 83, length: 4 }, // asdf
+            { type: 'parameter', modifiers: ['declaration'], start: 88, length: 3 }, // foo
             { type: 'type', modifiers: [], start: 93, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 105, length: 5 }, // value
             { type: 'type', modifiers: [], start: 112, length: 5 }, // Never
@@ -111,7 +111,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'type', modifiers: [], start: 142, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 148, length: 5 }, // value
             { type: 'type', modifiers: [], start: 155, length: 4 }, // Type
-            { type: 'function', modifiers: ['definition'], start: 169, length: 8 }, // inferred
+            { type: 'function', modifiers: ['declaration'], start: 169, length: 8 }, // inferred
             { type: 'variable', modifiers: [], start: 185, length: 5 }, // value
             { type: 'function', modifiers: ['defaultLibrary', 'builtin'], start: 207, length: 10 }, // isinstance
             { type: 'variable', modifiers: [], start: 218, length: 5 }, // value
@@ -136,11 +136,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 },
             { type: 'class', modifiers: [], start: 19, length: 8 },
-            { type: 'function', modifiers: ['definition'], start: 34, length: 3 },
-            { type: 'parameter', modifiers: ['definition'], start: 38, length: 1 },
+            { type: 'function', modifiers: ['declaration'], start: 34, length: 3 },
+            { type: 'parameter', modifiers: ['declaration'], start: 38, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 },
-            { type: 'parameter', modifiers: ['definition'], start: 47, length: 1 },
-            { type: 'parameter', modifiers: ['definition'], start: 52, length: 1 },
+            { type: 'parameter', modifiers: ['declaration'], start: 47, length: 1 },
+            { type: 'parameter', modifiers: ['declaration'], start: 52, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 58, length: 3 },
             { type: 'function', modifiers: [], start: 72, length: 3 },
             { type: 'type', modifiers: [], start: 79, length: 3 },
@@ -180,23 +180,23 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 75, length: 6 }, // typing
             { type: 'function', modifiers: [], start: 89, length: 5 }, // final
 
-            { type: 'class', modifiers: ['definition'], start: 115, length: 1 }, // A
+            { type: 'class', modifiers: ['declaration'], start: 115, length: 1 }, // A
             { type: 'decorator', modifiers: [], start: 96, length: 1 }, // @
             { type: 'function', modifiers: [], start: 97, length: 9 },
 
-            { type: 'class', modifiers: ['definition'], start: 154, length: 1 }, // B
+            { type: 'class', modifiers: ['declaration'], start: 154, length: 1 }, // B
             { type: 'decorator', modifiers: [], start: 123, length: 1 }, // @
             { type: 'namespace', modifiers: [], start: 124, length: 11 }, // dataclasses
             { type: 'function', modifiers: [], start: 136, length: 9 }, // dataclass
-            { type: 'method', modifiers: ['definition'], start: 176, length: 6 }, // method
+            { type: 'method', modifiers: ['declaration'], start: 176, length: 6 }, // method
             { type: 'decorator', modifiers: [], start: 161, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 162, length: 5 }, // final
-            { type: 'selfParameter', modifiers: ['definition'], start: 183, length: 4 }, // self
-            { type: 'method', modifiers: ['definition'], start: 220, length: 6 }, // static
+            { type: 'selfParameter', modifiers: ['declaration'], start: 183, length: 4 }, // self
+            { type: 'method', modifiers: ['declaration', 'static'], start: 220, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 198, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 199, length: 12 },
 
-            { type: 'function', modifiers: ['definition'], start: 256, length: 6 }, // cached
+            { type: 'function', modifiers: ['declaration'], start: 256, length: 6 }, // cached
             { type: 'decorator', modifiers: [], start: 235, length: 1 }, // @
             { type: 'namespace', modifiers: [], start: 236, length: 9 }, // functools
             { type: 'function', modifiers: [], start: 246, length: 5 }, // cache
@@ -207,25 +207,25 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('parameters.py');
         expect(result).toStrictEqual([
             // method
-            { type: 'class', modifiers: ['definition'], start: 6, length: 1 }, // C
-            { type: 'method', modifiers: ['definition'], start: 17, length: 8 }, // __init__
-            { type: 'selfParameter', modifiers: ['definition'], start: 26, length: 4 }, // self
-            { type: 'parameter', modifiers: ['definition'], start: 32, length: 1 }, // x
+            { type: 'class', modifiers: ['declaration'], start: 6, length: 1 }, // C
+            { type: 'method', modifiers: ['declaration'], start: 17, length: 8 }, // __init__
+            { type: 'selfParameter', modifiers: ['declaration'], start: 26, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration'], start: 32, length: 1 }, // x
             { type: 'selfParameter', modifiers: [], start: 44, length: 4 }, // self
-            { type: 'variable', modifiers: [], start: 49, length: 1 }, // x
+            { type: 'property', modifiers: [], start: 49, length: 1 }, // x
             { type: 'parameter', modifiers: [], start: 53, length: 1 }, // x
-            { type: 'method', modifiers: ['definition'], start: 81, length: 1 }, // m
+            { type: 'method', modifiers: ['declaration'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 61, length: 11 },
-            { type: 'clsParameter', modifiers: ['definition'], start: 83, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['declaration'], start: 83, length: 3 }, // cls
             { type: 'clsParameter', modifiers: [], start: 104, length: 3 }, // cls
             // function
-            { type: 'function', modifiers: ['definition'], start: 116, length: 1 }, // f
-            { type: 'parameter', modifiers: ['definition'], start: 118, length: 1 }, // x
-            { type: 'parameter', modifiers: ['definition'], start: 121, length: 1 }, // y
+            { type: 'function', modifiers: ['declaration'], start: 116, length: 1 }, // f
+            { type: 'parameter', modifiers: ['declaration'], start: 118, length: 1 }, // x
+            { type: 'parameter', modifiers: ['declaration'], start: 121, length: 1 }, // y
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 124, length: 3 }, // int
-            { type: 'function', modifiers: ['definition'], start: 138, length: 1 }, // g
-            { type: 'parameter', modifiers: ['definition'], start: 140, length: 1 }, // x
+            { type: 'function', modifiers: ['declaration'], start: 138, length: 1 }, // g
+            { type: 'parameter', modifiers: ['declaration'], start: 140, length: 1 }, // x
             { type: 'parameter', modifiers: [], start: 159, length: 1 }, // x
             { type: 'parameter', modifiers: [], start: 163, length: 1 }, // y
             { type: 'variable', modifiers: [], start: 169, length: 1 }, // z
@@ -233,8 +233,8 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'function', modifiers: [], start: 190, length: 1 }, // g
             { type: 'variable', modifiers: [], start: 192, length: 1 }, // z
             // lambda
-            { type: 'parameter', modifiers: ['definition'], start: 203, length: 1 }, // a
-            { type: 'parameter', modifiers: ['definition'], start: 206, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration'], start: 203, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration'], start: 206, length: 1 }, // b
             { type: 'parameter', modifiers: [], start: 209, length: 1 }, // a
             { type: 'parameter', modifiers: [], start: 213, length: 1 }, // b
         ]);
@@ -245,8 +245,8 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
             { type: 'type', modifiers: [], start: 19, length: 3 }, // Any
-            { type: 'function', modifiers: ['definition'], start: 28, length: 1 }, // f
-            { type: 'parameter', modifiers: ['definition'], start: 30, length: 1 }, // l
+            { type: 'function', modifiers: ['declaration'], start: 28, length: 1 }, // f
+            { type: 'parameter', modifiers: ['declaration'], start: 30, length: 1 }, // l
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 33, length: 4 }, // list
             { type: 'type', modifiers: [], start: 42, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 51, length: 1 }, // v
@@ -301,7 +301,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 // this `some_global` is referrring to the the builtin
                 { type: 'variable', modifiers: ['builtin'], start: 14, length: 11 },
                 // inside scope()...
-                { type: 'function', modifiers: ['definition'], start: 31, length: 5 },
+                { type: 'function', modifiers: ['declaration'], start: 31, length: 5 },
                 // this `some_global` is redefined inside the function scope
                 { type: 'variable', modifiers: [], start: 44, length: 11 },
                 { type: 'variable', modifiers: [], start: 64, length: 1 },
@@ -309,7 +309,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 // so this `some_global` refers to the redefined one, not to the builtin
                 { type: 'variable', modifiers: [], start: 72, length: 11 },
                 // inside in_function()...
-                { type: 'function', modifiers: ['definition'], start: 90, length: 11 },
+                { type: 'function', modifiers: ['declaration'], start: 90, length: 11 },
                 { type: 'variable', modifiers: [], start: 109, length: 1 },
                 { type: 'variable', modifiers: [], start: 113, length: 1 },
                 // this function is similar to scope(), but we don't redefine some_global, so it refers to the builtin

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -11,6 +11,21 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         ]);
     });
 
+    test('enum', () => {
+        const result = semanticTokenizeSampleFile('enum.py');
+        expect(result).toStrictEqual([
+            { type: 'namespace', modifiers: [], start: 5, length: 4 },
+            { type: 'enum', modifiers: [], start: 17, length: 7 },
+            { type: 'enum', modifiers: ['declaration'], start: 33, length: 11 },
+            { type: 'enum', modifiers: [], start: 45, length: 7 },
+            { type: 'enumMember', modifiers: [], start: 59, length: 3 },
+            { type: 'enumMember', modifiers: [], start: 71, length: 2 },
+            { type: 'variable', modifiers: [], start: 79, length: 1 },
+            { type: 'enum', modifiers: [], start: 83, length: 11 },
+            { type: 'enumMember', modifiers: [], start: 95, length: 3 },
+        ]);
+    });
+
     test('type annotation', () => {
         const result = semanticTokenizeSampleFile('type_annotation.py');
         expect(result).toStrictEqual([
@@ -51,41 +66,85 @@ if (process.platform !== 'win32' || !process.env['CI']) {
     test('final', () => {
         const result = semanticTokenizeSampleFile('final.py');
         expect(result).toStrictEqual([
-            { type: 'namespace', modifiers: [], start: 5, length: 6 },
-            { type: 'class', modifiers: [], start: 19, length: 5 },
-            { type: 'variable', modifiers: ['readonly'], start: 26, length: 3 },
-            { type: 'variable', modifiers: ['readonly'], start: 34, length: 3 },
+            { type: 'namespace', modifiers: [], start: 5, length: 4 },
+            { type: 'variable', modifiers: ['readonly'], start: 17, length: 2 },
+            { type: 'namespace', modifiers: [], start: 25, length: 6 },
             { type: 'class', modifiers: [], start: 39, length: 5 },
-            { type: 'variable', modifiers: [], start: 49, length: 1 },
-            { type: 'variable', modifiers: ['readonly'], start: 55, length: 2 },
-            { type: 'class', modifiers: [], start: 59, length: 5 },
-            { type: 'class', modifiers: ['declaration'], start: 76, length: 3 },
-            { type: 'property', modifiers: ['declaration'], start: 103, length: 3 },
-            { type: 'decorator', modifiers: [], start: 85, length: 1 },
-            { type: 'decorator', modifiers: [], start: 86, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 107, length: 4 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 116, length: 3 },
-            { type: 'property', modifiers: ['declaration'], start: 148, length: 3 },
-            { type: 'decorator', modifiers: [], start: 130, length: 1 },
-            { type: 'decorator', modifiers: [], start: 131, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 152, length: 4 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 161, length: 3 },
-            { type: 'property', modifiers: ['declaration'], start: 194, length: 3 },
-            { type: 'decorator', modifiers: [], start: 174, length: 1 },
-            { type: 'property', modifiers: ['readonly'], start: 175, length: 3 },
-            { type: 'function', modifiers: [], start: 179, length: 6 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 198, length: 4 },
-            { type: 'parameter', modifiers: ['declaration'], start: 204, length: 5 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 211, length: 3 },
-            { type: 'class', modifiers: [], start: 223, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 229, length: 3 },
-            { type: 'class', modifiers: [], start: 233, length: 3 },
-            { type: 'property', modifiers: [], start: 239, length: 3 },
-            { type: 'variable', modifiers: [], start: 244, length: 3 },
-            { type: 'class', modifiers: [], start: 250, length: 3 },
-            { type: 'variable', modifiers: [], start: 256, length: 1 },
-            { type: 'variable', modifiers: [], start: 260, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 264, length: 3 },
+            { type: 'function', modifiers: [], start: 46, length: 8 },
+            { type: 'variable', modifiers: ['readonly'], start: 56, length: 3 },
+            { type: 'variable', modifiers: ['readonly'], start: 64, length: 3 },
+            { type: 'class', modifiers: [], start: 69, length: 5 },
+            { type: 'variable', modifiers: [], start: 79, length: 1 },
+            { type: 'variable', modifiers: ['readonly'], start: 85, length: 2 },
+            { type: 'class', modifiers: [], start: 89, length: 5 },
+            { type: 'class', modifiers: ['declaration'], start: 107, length: 3 },
+            { type: 'method', modifiers: ['declaration'], start: 120, length: 8 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 129, length: 4 },
+            { type: 'selfParameter', modifiers: [], start: 144, length: 4 },
+            { type: 'property', modifiers: ['readonly'], start: 149, length: 8 },
+            { type: 'class', modifiers: [], start: 159, length: 5 },
+            { type: 'property', modifiers: ['declaration'], start: 193, length: 3 },
+            { type: 'decorator', modifiers: [], start: 175, length: 1 },
+            { type: 'decorator', modifiers: [], start: 176, length: 8 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 197, length: 4 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 206, length: 3 },
+            { type: 'property', modifiers: ['declaration'], start: 238, length: 3 },
+            { type: 'decorator', modifiers: [], start: 220, length: 1 },
+            { type: 'decorator', modifiers: [], start: 221, length: 8 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 242, length: 4 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 251, length: 3 },
+            { type: 'property', modifiers: ['declaration'], start: 284, length: 3 },
+            { type: 'decorator', modifiers: [], start: 264, length: 1 },
+            { type: 'property', modifiers: ['readonly'], start: 265, length: 3 },
+            { type: 'function', modifiers: [], start: 269, length: 6 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 288, length: 4 },
+            { type: 'parameter', modifiers: ['declaration'], start: 294, length: 5 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 },
+            { type: 'method', modifiers: ['declaration'], start: 320, length: 11 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 332, length: 4 },
+            { type: 'parameter', modifiers: ['declaration'], start: 338, length: 4 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 344, length: 3 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 352, length: 5 },
+            { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
+            { type: 'class', modifiers: ['declaration'], start: 385, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 394, length: 3 },
+            { type: 'class', modifiers: [], start: 399, length: 5 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 405, length: 3 },
+            { type: 'method', modifiers: ['declaration'], start: 425, length: 11 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 437, length: 4 },
+            { type: 'parameter', modifiers: ['declaration'], start: 443, length: 4 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 449, length: 3 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 457, length: 3 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 477, length: 3 },
+            { type: 'parameter', modifiers: [], start: 481, length: 4 },
+            { type: 'method', modifiers: ['declaration'], start: 510, length: 11 },
+            { type: 'decorator', modifiers: [], start: 492, length: 1 },
+            { type: 'decorator', modifiers: [], start: 493, length: 8 },
+            { type: 'selfParameter', modifiers: ['declaration'], start: 522, length: 4 },
+            { type: 'parameter', modifiers: ['declaration'], start: 528, length: 4 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 534, length: 3 },
+            { type: 'parameter', modifiers: ['declaration'], start: 539, length: 5 },
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 546, length: 3 },
+            { type: 'class', modifiers: [], start: 567, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 573, length: 3 },
+            { type: 'class', modifiers: [], start: 577, length: 3 },
+            { type: 'property', modifiers: [], start: 583, length: 3 },
+            { type: 'variable', modifiers: [], start: 588, length: 3 },
+            { type: 'class', modifiers: [], start: 594, length: 3 },
+            { type: 'variable', modifiers: [], start: 600, length: 1 },
+            { type: 'variable', modifiers: [], start: 604, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 608, length: 3 },
+            { type: 'variable', modifiers: [], start: 612, length: 7 },
+            { type: 'variable', modifiers: [], start: 622, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 626, length: 8 },
+            { type: 'variable', modifiers: [], start: 635, length: 3 },
+            { type: 'variable', modifiers: [], start: 641, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 645, length: 2 },
+            { type: 'class', modifiers: [], start: 650, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 654, length: 3 },
+            { type: 'variable', modifiers: [], start: 658, length: 3 },
+            { type: 'class', modifiers: [], start: 664, length: 3 },
+            { type: 'property', modifiers: [], start: 670, length: 4 },
         ]);
     });
 
@@ -174,32 +233,34 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('decorators.py');
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 7, length: 11 }, // dataclasses
-            { type: 'namespace', modifiers: [], start: 24, length: 11 }, // dataclasses
-            { type: 'function', modifiers: [], start: 43, length: 9 }, // dataclass
-            { type: 'namespace', modifiers: [], start: 60, length: 9 }, // functools
+            { type: 'namespace', modifiers: [], start: 26, length: 9 }, // functools
+            { type: 'namespace', modifiers: [], start: 41, length: 11 }, // dataclasses
+            { type: 'function', modifiers: [], start: 60, length: 9 }, // dataclasses
             { type: 'namespace', modifiers: [], start: 75, length: 6 }, // typing
             { type: 'function', modifiers: [], start: 89, length: 5 }, // final
 
-            { type: 'class', modifiers: ['declaration'], start: 115, length: 1 }, // A
-            { type: 'decorator', modifiers: [], start: 96, length: 1 }, // @
-            { type: 'function', modifiers: [], start: 97, length: 9 },
+            { type: 'class', modifiers: ['declaration'], start: 116, length: 1 }, // A
+            { type: 'decorator', modifiers: [], start: 97, length: 1 }, // @
+            { type: 'function', modifiers: [], start: 98, length: 9 },
 
-            { type: 'class', modifiers: ['declaration'], start: 154, length: 1 }, // B
-            { type: 'decorator', modifiers: [], start: 123, length: 1 }, // @
-            { type: 'namespace', modifiers: [], start: 124, length: 11 }, // dataclasses
-            { type: 'function', modifiers: [], start: 136, length: 9 }, // dataclass
-            { type: 'method', modifiers: ['declaration'], start: 176, length: 6 }, // method
-            { type: 'decorator', modifiers: [], start: 161, length: 1 }, // @
-            { type: 'decorator', modifiers: [], start: 162, length: 5 }, // final
-            { type: 'selfParameter', modifiers: ['declaration'], start: 183, length: 4 }, // self
-            { type: 'method', modifiers: ['declaration', 'static'], start: 220, length: 6 }, // static
-            { type: 'decorator', modifiers: [], start: 198, length: 1 }, // @
-            { type: 'decorator', modifiers: [], start: 199, length: 12 },
+            { type: 'class', modifiers: ['declaration'], start: 155, length: 1 }, // B
+            { type: 'decorator', modifiers: [], start: 124, length: 1 }, // @
+            { type: 'namespace', modifiers: [], start: 125, length: 11 }, // dataclasses
+            { type: 'function', modifiers: [], start: 137, length: 9 }, // dataclass
+            { type: 'method', modifiers: ['declaration'], start: 177, length: 6 }, // method
+            { type: 'decorator', modifiers: [], start: 162, length: 1 }, // @
+            { type: 'decorator', modifiers: [], start: 163, length: 5 }, // final
+            { type: 'selfParameter', modifiers: ['declaration'], start: 184, length: 4 }, // self
+            { type: 'method', modifiers: ['declaration', 'static'], start: 221, length: 6 }, // static
+            { type: 'decorator', modifiers: [], start: 199, length: 1 }, // @
+            { type: 'decorator', modifiers: [], start: 200, length: 12 },
 
-            { type: 'function', modifiers: ['declaration'], start: 256, length: 6 }, // cached
-            { type: 'decorator', modifiers: [], start: 235, length: 1 }, // @
-            { type: 'namespace', modifiers: [], start: 236, length: 9 }, // functools
-            { type: 'function', modifiers: [], start: 246, length: 5 }, // cache
+            { type: 'function', modifiers: ['declaration'], start: 257, length: 6 }, // cached
+            { type: 'decorator', modifiers: [], start: 236, length: 1 }, // @
+            { type: 'namespace', modifiers: [], start: 237, length: 9 }, // functools
+            { type: 'function', modifiers: [], start: 247, length: 5 }, // cache
+            { type: 'class', modifiers: [], start: 272, length: 1 }, // B
+            { type: 'method', modifiers: ['static'], start: 274, length: 6 }, // static
         ]);
     });
 

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -72,7 +72,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 161, length: 3 },
             { type: 'property', modifiers: ['declaration'], start: 194, length: 3 },
             { type: 'decorator', modifiers: [], start: 174, length: 1 },
-            { type: 'property', modifiers: [], start: 175, length: 3 },
+            { type: 'property', modifiers: ['readonly'], start: 175, length: 3 },
             { type: 'function', modifiers: [], start: 179, length: 6 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 198, length: 4 },
             { type: 'parameter', modifiers: ['declaration'], start: 204, length: 5 },


### PR DESCRIPTION
- fixes #1318
- fixes #1391
- fixes #482
- fixes #364
- fixes #262
- fixes #1059

This PR improved semantic tokens and their modifiers in a few ways:

- The modifier `declaration` is used instead of `definition` (consistent with Pylance).
- Enum classes and their members are now represented using the `enum` and `enumMember` token kinds (consistent with Pylance).
- The `property` token kind is used for the name of a property, a magic member access function (e.g. `__getattr__`), and for all member variable accesses (the first and last parts are consistent with Pylance).
- The modifier `static` is applied to static methods.
- Immutable values are detected in more contexts.

The commit messages given some more details, including some small implementation adjustments.
The semantic tokens tests have been adapted to reflect these changes.

The following picture shows the difference using _Picta_, my VS Code theme, where _orange italics_ are used for `property` tokens, _blue italics_ are used for enum members, and underlined values are constant (enum classes and static functions are not differentiated):

<img width="1150" height="848" alt="CmpPyright" src="https://github.com/user-attachments/assets/536d3a1e-d93f-40dd-9136-e28353966e82" />

This PR does not cover all differences to Pylance that might be worth addressing (and some differences are indeed desirable), but it addresses some significant ones.