### PR TITLE
docs(installation): `uv pip install` -> `uv tool install`

### DIFF
--- a/docs/installation/command-line-and-language-server.md
+++ b/docs/installation/command-line-and-language-server.md
@@ -17,7 +17,7 @@ this makes it far more convenient for python developers to use, since there's no
      or install it globally:
 
      ```
-     uv tool install basedpyright@latest
+     uv tool install basedpyright
      ```
 
 === "pdm"


### PR DESCRIPTION
`pip install` has appeared in pip section, so I think it's more suitable to write `uv tool install` command here.