### PR TITLE
update zed installation instructions to reflect that basedpyright is now the default language server

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,19 +1,27 @@
 {
   "languages": {
     "Python": {
-      "language_servers": ["basedpyright", "ruff", "!pyright", "!pylsp"]
+      "language_servers": [
+        "basedpyright",
+        "ruff"
+      ],
+      "format_on_save": "on",
+      "formatter": [
+        {
+          "code_actions": {
+            "source.organizeImports.ruff": true,
+            "source.fixAll.ruff": true
+          }
+        },
+        {
+          "language_server": {
+            "name": "ruff"
+          }
+        }
+      ]        
     }
-  },
-  "lsp": {
-    "basedpyright": {
-      "binary": {
-        "path": ".venv/bin/basedpyright-langserver",
-        "arguments": ["--stdio"]
-      }
-    }
-  },
+  }, 
   "auto_install_extensions": {
-    "basedpyright": true,
     "ruff": true
   }
 }

--- a/docs/installation/ides.md
+++ b/docs/installation/ides.md
@@ -182,46 +182,4 @@ You can verify the active configuration by running `hx --health python`
 
 ## Zed
 
-Install the [BasedPyright extension](https://github.com/m1guer/basedpyright-zed) through Zed's extension manager.
-
-Enable and configure basedpyright under Zed settings:
-
-```json
-{
-    "languages": {
-        "Python": {
-            "language_servers": [
-                "basedpyright",
-                // disable the other python language servers
-                "!pyright",
-                "!pylsp"
-            ]
-        }
-    }
-}
-```
-
-??? tip "if adding basedpyright as a development dependency to your project"
-
-    we recommend using project settings (`.zed/settings.json`) with the following:
-
-    - set the path to the language server located inside your venv so that it uses the correct version of basedpyright instead of a globally installed version
-    - add basedpyright to `auto_install_extensions` so that it's automatically installed for other contributors working on your project
-
-    ```json title=".zed/settings.json"
-    {
-        "lsp": {
-            "basedpyright": {
-                "binary": {
-                    "path": ".venv/bin/basedpyright-langserver",
-                    "arguments": ["--stdio"]
-                }
-            }
-        },
-        "auto_install_extensions": {
-            "basedpyright": true
-        }
-    }
-    ```
-
-    you should commit this file so that these settings are automatically applied for other contributors.
+basedpyright is the default language server for python in zed. [see the docs](https://zed.dev/docs/languages/python#basedpyright) for more information.


### PR DESCRIPTION
fixes #1466 