### PR TITLE
Report error for dubious rename actions

### DIFF
--- a/packages/pyright-internal/src/languageService/renameProvider.ts
+++ b/packages/pyright-internal/src/languageService/renameProvider.ts
@@ -20,6 +20,7 @@ import { Uri } from '../common/uri/uri';
 import { convertToWorkspaceEdit } from '../common/workspaceEditUtils';
 import { ReferencesProvider, ReferencesResult } from '../languageService/referencesProvider';
 import { ParseFileResults } from '../parser/parser';
+import { Tokenizer } from '../parser/tokenizer';
 import { IPythonMode } from '../analyzer/sourceFile';
 import { LanguageServerInterface } from '../common/languageServerInterface';
 
@@ -81,6 +82,16 @@ export class RenameProvider {
             isDefaultWorkspace,
             isUntitled
         );
+
+        // not returning `null` on error because that shows an extra "No Result" message
+        if (Tokenizer.isPythonKeyword(newName)) {
+            this._ls.window.showWarningMessage(`Cannot rename to ${newName}: it's a Python keyword`);
+            return {};
+        }
+        if (!Tokenizer.isPythonIdentifier(newName)) {
+            this._ls.window.showWarningMessage(`Can only rename to a valid Python identitifer, got: ${newName}`);
+            return {};
+        }
 
         switch (renameMode) {
             case 'singleFileMode':


### PR DESCRIPTION
Right now, pyright/basedpyright allow you to rename a function/class/whatever to anything, including:

- keywords
- strings with spaces
- strings with invalid characters like `()[]123` or starting with a digit

I've been burned by this in the past, when I renamed something and later realized I renamed it to some nonsense (and now you can't fix it because it has a space, or something like that). I think it's not expected of refactoring actions to make invalid changes

After this PR, you get this message (in VSCode) instead of a dubious rename:

<img width="480" height="86" alt="Request textDocument rename failed with message: Can only rename to a valid Python identifier, got: yield" src="https://github.com/user-attachments/assets/b9bf5042-82b4-4d60-bff5-f03325ed3f57" />

