### PR TITLE
enable `basedpyright.analysis.inlayHints.genericTypes` by default

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -53,7 +53,7 @@ the following settings are exclusive to basedpyright
 
 ![](inlayHints.functionReturnTypes.png)
 
-**basedpyright.analysis.inlayHints.genericTypes** [boolean]: Whether to show inlay hints on inferred generic types. Defaults to `false`:
+**basedpyright.analysis.inlayHints.genericTypes** [boolean]: Whether to show inlay hints on inferred generic types. Defaults to `true`:
 
 ![](inlayHints.genericTypes.png)
 

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -1933,7 +1933,7 @@
                 },
                 "basedpyright.analysis.inlayHints.genericTypes": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Whether to show inlay hints on inferred generic types.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
fixes: #1512