### PR TITLE
Use declarations as the primary source of semantic tokens

### DIFF
--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -11,7 +11,6 @@ import {
     isNever,
     isOverloaded,
     isTypeVar,
-    isUnion,
     isUnknown,
     NeverType,
     OverloadedType,
@@ -169,7 +168,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
                 const type = this._getType(node);
                 this._addItemForNameNode(
                     node,
-                    type && isUnion(type) ? SemanticTokenTypes.type : SemanticTokenTypes.class,
+                    type && isClass(type) ? SemanticTokenTypes.class : SemanticTokenTypes.type,
                     []
                 );
                 return;
@@ -412,7 +411,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         ) {
             if (isClass(type)) return this._getClassTokenType(type, declarations, modifiers);
             // Pylance uses “class” for type aliases, we use “type” for unions
-            return isUnion(type) ? SemanticTokenTypes.type : SemanticTokenTypes.class;
+            return isClass(type) ? SemanticTokenTypes.class : SemanticTokenTypes.type;
         }
 
         // Detect variables that store a function or an overloaded function

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -209,7 +209,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         switch (type.category) {
             case TypeCategory.Any:
                 if (type.props?.specialForm) {
-                    this._addItemForNameNode(node, SemanticTokenTypes.type, []);
+                    this._addItemForNameNode(node, SemanticTokenTypes.class, []);
                 }
                 return;
             // these are handled below
@@ -464,7 +464,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
     private _visitFunctionWithType(node: NameNode, type: FunctionType, declarations: Declaration[]) {
         // type alias to Callable
         if (!TypeBase.isInstance(type)) {
-            this._addItemForNameNode(node, SemanticTokenTypes.type, []);
+            this._addItemForNameNode(node, SemanticTokenTypes.class, []);
             return;
         }
         const modifiers: TokenModifiers[] = [];

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -463,11 +463,10 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         }
 
         // If a variable is a class member and not handled by any other case, use “property”
-        return isParam
-            ? SemanticTokenTypes.parameter
-            : isClassMember
-            ? SemanticTokenTypes.property
-            : SemanticTokenTypes.variable;
+        if (isParam) {
+            return SemanticTokenTypes.parameter;
+        }
+        return isClassMember ? SemanticTokenTypes.property : SemanticTokenTypes.variable;
     }
 
     // For a given attribute access, gather information about the magic attribute methods

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -238,7 +238,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
                 return;
             case TypeCategory.Union:
                 if (!TypeBase.isInstance(type)) {
-                    this._addItemForNameNode(node, SemanticTokenTypes.type, []);
+                    this._addItemForNameNode(node, SemanticTokenTypes.class, []);
                     return;
                 }
                 break;

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -434,13 +434,10 @@ export class SemanticTokensWalker extends ParseTreeWalker {
             return SemanticTokenTypes.typeParameter;
         }
 
-        // Detect type aliases
-        // The “typeAliasInfo” condition is required for aliases to typing-only constructs such as “Callable”
-        // Module aliases also provide “typeAliasInfo” (for some reason), so an additional check is necessary
-        // This follows Pylance’s somewhat peculiar rules: Variables are marked as type aliases very liberally,
-        // but “property” etc. take precedence
+        // Detect variables that store a type (i.e. something that can be instantiated)
+        // and do not fall into a category that is handled elsewhere
         if (
-            (type.props?.typeAliasInfo?.shared.isTypeAliasType || TypeBase.isInstantiable(type)) &&
+            TypeBase.isInstantiable(type) &&
             ![
                 TypeCategory.Unbound,
                 TypeCategory.Unknown,

--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -166,7 +166,12 @@ export class SemanticTokensWalker extends ParseTreeWalker {
             }
             case DeclarationType.TypeAlias: {
                 // Pylance uses “class” for type aliases
-                this._addItemForNameNode(node, SemanticTokenTypes.class, []);
+                const type = this._getType(node);
+                this._addItemForNameNode(
+                    node,
+                    type && isUnion(type) ? SemanticTokenTypes.type : SemanticTokenTypes.class,
+                    []
+                );
                 return;
             }
             case DeclarationType.Function: {

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -19,6 +19,8 @@ export enum CustomSemanticTokenTypes {
 
 export enum CustomSemanticTokenModifiers {
     builtin = 'builtin', // parity with pylance
+    // custom modifier to distinguish class/instance variables which store a type/function/type variable/etc.
+    classMember = 'classMember',
 }
 
 export const tokenTypes: string[] = [
@@ -47,6 +49,7 @@ export const tokenModifiers: string[] = [
     SemanticTokenModifiers.async,
     SemanticTokenModifiers.defaultLibrary,
     CustomSemanticTokenModifiers.builtin,
+    CustomSemanticTokenModifiers.classMember,
 ];
 
 export const SemanticTokensProviderLegend = {

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -22,8 +22,13 @@ export enum CustomSemanticTokenModifiers {
     builtin = 'builtin',
     /** distinguishes class/instance variables, especially when these are types/functions/etc. */
     classMember = 'classMember',
-    /** distinguishes function arguments, especially when these are types/functions/etc. */
-    argument = 'argument',
+    /**
+     * Distinguishes function parameters.
+     * Note that this custom modifier exists despite the `parameter` token type so that a parameter
+     * with another token type (e.g. `function` or `class`) can still retain the information
+     * about whether or not it is a parameter.
+     */
+    parameter = 'parameter',
 }
 
 export const tokenTypes: string[] = [
@@ -53,7 +58,7 @@ export const tokenModifiers: string[] = [
     SemanticTokenModifiers.defaultLibrary,
     CustomSemanticTokenModifiers.builtin,
     CustomSemanticTokenModifiers.classMember,
-    CustomSemanticTokenModifiers.argument,
+    CustomSemanticTokenModifiers.parameter,
 ];
 
 export const SemanticTokensProviderLegend = {

--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -18,9 +18,12 @@ export enum CustomSemanticTokenTypes {
 }
 
 export enum CustomSemanticTokenModifiers {
-    builtin = 'builtin', // parity with pylance
-    // custom modifier to distinguish class/instance variables which store a type/function/type variable/etc.
+    /** built-in symbols (parity with pylance) */
+    builtin = 'builtin',
+    /** distinguishes class/instance variables, especially when these are types/functions/etc. */
     classMember = 'classMember',
+    /** distinguishes function arguments, especially when these are types/functions/etc. */
+    argument = 'argument',
 }
 
 export const tokenTypes: string[] = [
@@ -50,6 +53,7 @@ export const tokenModifiers: string[] = [
     SemanticTokenModifiers.defaultLibrary,
     CustomSemanticTokenModifiers.builtin,
     CustomSemanticTokenModifiers.classMember,
+    CustomSemanticTokenModifiers.argument,
 ];
 
 export const SemanticTokensProviderLegend = {

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/class_members.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/class_members.py
@@ -1,0 +1,40 @@
+import os
+from typing import Any, Callable, Final, TypeVar
+
+
+class A:
+    cvar: int = 3
+
+    def __init__(self, f: Callable[[], int], t: type[int]):
+        self.f: Final[Callable[[], int]] = f
+        self.t: type[int] = t
+
+    @property
+    def b(self) -> int:
+        return self.f()
+
+    @b.setter
+    def b(self, value: int) -> None:
+        pass
+
+    @staticmethod
+    def d(i: int) -> float:
+        return i * 2.5
+
+    def __getattr__(self, name: str) -> Callable[[], float]:
+        return lambda: 3.14
+
+def ufun0(a):
+    a = a.T.maximum()
+
+
+def ufun1(b: Any) -> Any:
+    return b.as_integer_ratio()
+
+
+a = A(lambda: int(A.d(3)), int)
+print(a.b, a.f, os.path.pardir)
+c = a.t
+d: Any = a.abc()
+A.cvar = 4 + d.is_integer()
+e = ufun1(12)

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/final.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/final.py
@@ -16,7 +16,7 @@ class Foo:
 
     @property
     def bar(self) -> int: ...
-    @foo.setter
+    @bar.setter
     def bar(self, value: int): ...
 
     def __getattr__(self, name: str) -> float:

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/never.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/never.py
@@ -23,4 +23,4 @@ def inferred():
         value2
 
 type Baz = Never
-baz: Baz
+bat: Baz

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/unknown.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/unknown.py
@@ -4,5 +4,17 @@ def f(l: list) -> Any:
     v = l[0]
     return v
 
+
+def f1(a):
+    a = a.T.maximum()
+
+
+def f2(b: Any) -> Any:
+    return b.as_integer_ratio()
+
+
 g(foo)
 bar = f(...)
+
+a, b = f2(12)
+c = a.bit_length() + b.bit_length()

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -27,66 +27,71 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 80, length: 3 }, // int
             // __init__
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 97, length: 8 }, // __init__
-            { type: 'selfParameter', modifiers: ['declaration'], start: 106, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration'], start: 112, length: 1 }, // f
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 106, length: 4 }, // self
+            { type: 'function', modifiers: ['declaration', 'argument'], start: 112, length: 1 }, // f
             { type: 'class', modifiers: [], start: 115, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 128, length: 3 }, // int
-            { type: 'parameter', modifiers: ['declaration'], start: 134, length: 1 }, // t
+            {
+                type: 'class',
+                modifiers: ['declaration', 'argument', 'defaultLibrary', 'builtin'],
+                start: 134,
+                length: 1,
+            }, // t
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 137, length: 4 }, // type
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 142, length: 3 }, // int
-            { type: 'selfParameter', modifiers: [], start: 157, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['argument'], start: 157, length: 4 }, // self
             { type: 'function', modifiers: ['readonly', 'classMember'], start: 162, length: 1 }, // f
             { type: 'class', modifiers: [], start: 165, length: 5 }, // Final
             { type: 'class', modifiers: [], start: 171, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 184, length: 3 }, // int
-            { type: 'parameter', modifiers: [], start: 192, length: 1 }, // f
-            { type: 'selfParameter', modifiers: [], start: 202, length: 4 }, // self
+            { type: 'function', modifiers: ['argument'], start: 192, length: 1 }, // f
+            { type: 'selfParameter', modifiers: ['argument'], start: 202, length: 4 }, // self
             { type: 'class', modifiers: ['classMember', 'defaultLibrary', 'builtin'], start: 207, length: 1 }, // t
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 210, length: 4 }, // type
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 215, length: 3 }, // int
-            { type: 'parameter', modifiers: [], start: 222, length: 1 }, // t
+            { type: 'class', modifiers: ['argument', 'defaultLibrary', 'builtin'], start: 222, length: 1 }, // t
             // b
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 247, length: 1 }, // b
             { type: 'decorator', modifiers: [], start: 229, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 230, length: 8 }, // property
-            { type: 'selfParameter', modifiers: ['declaration'], start: 249, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 249, length: 4 }, // self
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 258, length: 3 }, // int
-            { type: 'selfParameter', modifiers: [], start: 278, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['argument'], start: 278, length: 4 }, // self
             { type: 'function', modifiers: ['readonly', 'classMember'], start: 283, length: 1 }, // f
             // b.setter
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 310, length: 1 }, // b
             { type: 'decorator', modifiers: [], start: 292, length: 1 }, // @
             { type: 'property', modifiers: ['classMember'], start: 293, length: 1 }, // b
             { type: 'method', modifiers: ['classMember'], start: 295, length: 6 }, // setter
-            { type: 'selfParameter', modifiers: ['declaration'], start: 312, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration'], start: 318, length: 5 }, // value
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 312, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 318, length: 5 }, // value
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 325, length: 3 }, // int
             // d
             { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 379, length: 1 }, // d
             { type: 'decorator', modifiers: [], start: 357, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 358, length: 12 }, // staticmethod
-            { type: 'parameter', modifiers: ['declaration'], start: 381, length: 1 }, // i
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 381, length: 1 }, // i
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 384, length: 3 }, // int
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 392, length: 5 }, // float
-            { type: 'parameter', modifiers: [], start: 414, length: 1 }, // i
+            { type: 'parameter', modifiers: ['argument'], start: 414, length: 1 }, // i
             // __getattr__
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 431, length: 11 }, // __getattr__
-            { type: 'selfParameter', modifiers: ['declaration'], start: 443, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration'], start: 449, length: 4 }, // name
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 443, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 449, length: 4 }, // name
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 455, length: 3 }, // str
             { type: 'class', modifiers: [], start: 463, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 476, length: 5 }, // float
             // ufun0
             { type: 'function', modifiers: ['declaration'], start: 517, length: 5 }, // ufun0
-            { type: 'parameter', modifiers: ['declaration'], start: 523, length: 1 }, // a
-            { type: 'parameter', modifiers: [], start: 531, length: 1 }, // a
-            { type: 'parameter', modifiers: [], start: 535, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 523, length: 1 }, // a
+            { type: 'parameter', modifiers: ['argument'], start: 531, length: 1 }, // a
+            { type: 'parameter', modifiers: ['argument'], start: 535, length: 1 }, // a
             // ufun1
             { type: 'function', modifiers: ['declaration'], start: 555, length: 5 }, // ufun1
-            { type: 'parameter', modifiers: ['declaration'], start: 561, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 561, length: 1 }, // b
             { type: 'class', modifiers: [], start: 564, length: 3 }, // Any
             { type: 'class', modifiers: [], start: 572, length: 3 }, // Any
-            { type: 'parameter', modifiers: [], start: 588, length: 1 }, // b
+            { type: 'parameter', modifiers: ['argument'], start: 588, length: 1 }, // b
             // a = A(lambda: int(A.d(3)), int)
             { type: 'variable', modifiers: [], start: 611, length: 1 }, // a
             { type: 'class', modifiers: [], start: 615, length: 1 }, // A
@@ -193,30 +198,30 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             // Foo
             { type: 'class', modifiers: ['declaration'], start: 107, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 120, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 129, length: 4 },
-            { type: 'selfParameter', modifiers: [], start: 144, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 129, length: 4 },
+            { type: 'selfParameter', modifiers: ['argument'], start: 144, length: 4 },
             { type: 'property', modifiers: ['readonly', 'classMember'], start: 149, length: 8 },
             { type: 'class', modifiers: [], start: 159, length: 5 },
             { type: 'property', modifiers: ['declaration', 'classMember', 'readonly'], start: 193, length: 3 },
             { type: 'decorator', modifiers: [], start: 175, length: 1 },
             { type: 'decorator', modifiers: [], start: 176, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 197, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 197, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 206, length: 3 },
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 238, length: 3 },
             { type: 'decorator', modifiers: [], start: 220, length: 1 },
             { type: 'decorator', modifiers: [], start: 221, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 242, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 242, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 251, length: 3 },
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 284, length: 3 },
             { type: 'decorator', modifiers: [], start: 264, length: 1 },
             { type: 'property', modifiers: ['classMember'], start: 265, length: 3 },
             { type: 'method', modifiers: ['classMember'], start: 269, length: 6 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 288, length: 4 },
-            { type: 'parameter', modifiers: ['declaration'], start: 294, length: 5 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 288, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 294, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 320, length: 11 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 332, length: 4 },
-            { type: 'parameter', modifiers: ['declaration'], start: 338, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 332, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 338, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 344, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 352, length: 5 },
             { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
@@ -226,19 +231,19 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: [], start: 399, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 405, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 425, length: 11 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 437, length: 4 },
-            { type: 'parameter', modifiers: ['declaration'], start: 443, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 437, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 443, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 449, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 457, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 477, length: 3 },
-            { type: 'parameter', modifiers: [], start: 481, length: 4 },
+            { type: 'parameter', modifiers: ['argument'], start: 481, length: 4 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 510, length: 11 },
             { type: 'decorator', modifiers: [], start: 492, length: 1 },
             { type: 'decorator', modifiers: [], start: 493, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration'], start: 522, length: 4 },
-            { type: 'parameter', modifiers: ['declaration'], start: 528, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 522, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 528, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 534, length: 3 },
-            { type: 'parameter', modifiers: ['declaration'], start: 539, length: 5 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 539, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 546, length: 3 },
             // Foo().foo
             { type: 'class', modifiers: [], start: 567, length: 3 },
@@ -282,11 +287,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'function', modifiers: ['declaration'], start: 54, length: 3 }, // baz
             { type: 'class', modifiers: [], start: 63, length: 5 }, // Never
             { type: 'function', modifiers: ['declaration'], start: 83, length: 4 }, // asdf
-            { type: 'parameter', modifiers: ['declaration'], start: 88, length: 3 }, // foo
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 88, length: 3 }, // foo
             { type: 'class', modifiers: [], start: 93, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 105, length: 5 }, // value
             { type: 'class', modifiers: [], start: 112, length: 5 }, // Never
-            { type: 'parameter', modifiers: [], start: 120, length: 3 }, // foo
+            { type: 'parameter', modifiers: ['argument'], start: 120, length: 3 }, // foo
             { type: 'variable', modifiers: [], start: 128, length: 5 }, // value
             { type: 'class', modifiers: [], start: 135, length: 4 }, // Type
             { type: 'class', modifiers: [], start: 142, length: 5 }, // Never
@@ -318,10 +323,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 5, length: 6 },
             { type: 'class', modifiers: [], start: 19, length: 8 },
             { type: 'function', modifiers: ['declaration'], start: 34, length: 3 },
-            { type: 'parameter', modifiers: ['declaration'], start: 38, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 38, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 },
-            { type: 'parameter', modifiers: ['declaration'], start: 47, length: 1 },
-            { type: 'parameter', modifiers: ['declaration'], start: 52, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 47, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 52, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 58, length: 3 },
             { type: 'function', modifiers: [], start: 72, length: 3 },
             { type: 'type', modifiers: [], start: 79, length: 3 },
@@ -372,7 +377,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 177, length: 6 }, // method
             { type: 'decorator', modifiers: [], start: 162, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 163, length: 5 }, // final
-            { type: 'selfParameter', modifiers: ['declaration'], start: 184, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 184, length: 4 }, // self
             { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 221, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 199, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 200, length: 12 }, // staticmethod
@@ -392,34 +397,34 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             // method
             { type: 'class', modifiers: ['declaration'], start: 6, length: 1 }, // C
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 17, length: 8 }, // __init__
-            { type: 'selfParameter', modifiers: ['declaration'], start: 26, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration'], start: 32, length: 1 }, // x
-            { type: 'selfParameter', modifiers: [], start: 44, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 26, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 32, length: 1 }, // x
+            { type: 'selfParameter', modifiers: ['argument'], start: 44, length: 4 }, // self
             { type: 'property', modifiers: ['classMember'], start: 49, length: 1 }, // x
-            { type: 'parameter', modifiers: [], start: 53, length: 1 }, // x
+            { type: 'parameter', modifiers: ['argument'], start: 53, length: 1 }, // x
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 61, length: 11 }, // classmethod
-            { type: 'clsParameter', modifiers: ['declaration'], start: 83, length: 3 }, // cls
-            { type: 'clsParameter', modifiers: [], start: 104, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['declaration', 'argument'], start: 83, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['argument'], start: 104, length: 3 }, // cls
             // function
             { type: 'function', modifiers: ['declaration'], start: 116, length: 1 }, // f
-            { type: 'parameter', modifiers: ['declaration'], start: 118, length: 1 }, // x
-            { type: 'parameter', modifiers: ['declaration'], start: 121, length: 1 }, // y
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 118, length: 1 }, // x
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 121, length: 1 }, // y
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 124, length: 3 }, // int
             { type: 'function', modifiers: ['declaration'], start: 138, length: 1 }, // g
-            { type: 'parameter', modifiers: ['declaration'], start: 140, length: 1 }, // x
-            { type: 'parameter', modifiers: [], start: 159, length: 1 }, // x
-            { type: 'parameter', modifiers: [], start: 163, length: 1 }, // y
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 140, length: 1 }, // x
+            { type: 'parameter', modifiers: ['argument'], start: 159, length: 1 }, // x
+            { type: 'parameter', modifiers: ['argument'], start: 163, length: 1 }, // y
             { type: 'variable', modifiers: [], start: 169, length: 1 }, // z
-            { type: 'parameter', modifiers: [], start: 177, length: 1 }, // x
+            { type: 'parameter', modifiers: ['argument'], start: 177, length: 1 }, // x
             { type: 'function', modifiers: [], start: 190, length: 1 }, // g
             { type: 'variable', modifiers: [], start: 192, length: 1 }, // z
             // lambda
-            { type: 'parameter', modifiers: ['declaration'], start: 203, length: 1 }, // a
-            { type: 'parameter', modifiers: ['declaration'], start: 206, length: 1 }, // b
-            { type: 'parameter', modifiers: [], start: 209, length: 1 }, // a
-            { type: 'parameter', modifiers: [], start: 213, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 203, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 206, length: 1 }, // b
+            { type: 'parameter', modifiers: ['argument'], start: 209, length: 1 }, // a
+            { type: 'parameter', modifiers: ['argument'], start: 213, length: 1 }, // b
         ]);
     });
 
@@ -429,22 +434,22 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
             { type: 'class', modifiers: [], start: 19, length: 3 }, // Any
             { type: 'function', modifiers: ['declaration'], start: 28, length: 1 }, // f
-            { type: 'parameter', modifiers: ['declaration'], start: 30, length: 1 }, // l
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 30, length: 1 }, // l
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 33, length: 4 }, // list
             { type: 'class', modifiers: [], start: 42, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 51, length: 1 }, // v
-            { type: 'parameter', modifiers: [], start: 55, length: 1 }, // l
+            { type: 'parameter', modifiers: ['argument'], start: 55, length: 1 }, // l
             { type: 'variable', modifiers: [], start: 71, length: 1 }, // v
             { type: 'function', modifiers: ['declaration'], start: 79, length: 2 }, // f1
-            { type: 'parameter', modifiers: ['declaration'], start: 82, length: 1 }, // a
-            { type: 'parameter', modifiers: [], start: 90, length: 1 }, // a
-            { type: 'parameter', modifiers: [], start: 94, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 82, length: 1 }, // a
+            { type: 'parameter', modifiers: ['argument'], start: 90, length: 1 }, // a
+            { type: 'parameter', modifiers: ['argument'], start: 94, length: 1 }, // a
             // `T` and `maximum` should be ignored
             { type: 'function', modifiers: ['declaration'], start: 114, length: 2 }, // f2
-            { type: 'parameter', modifiers: ['declaration'], start: 117, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 117, length: 1 }, // b
             { type: 'class', modifiers: [], start: 120, length: 3 }, // Any
             { type: 'class', modifiers: [], start: 128, length: 3 }, // Any
-            { type: 'parameter', modifiers: [], start: 144, length: 1 }, // b
+            { type: 'parameter', modifiers: ['argument'], start: 144, length: 1 }, // b
             // `as_integer_ratio`, `g`, and `foo` should be ignored
             { type: 'variable', modifiers: [], start: 174, length: 3 }, // bar
             { type: 'function', modifiers: [], start: 180, length: 1 }, // f

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -11,6 +11,117 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         ]);
     });
 
+    test('class_members', () => {
+        const result = semanticTokenizeSampleFile('class_members.py');
+        expect(result).toStrictEqual([
+            { type: 'namespace', modifiers: [], start: 7, length: 2 }, // os
+            { type: 'namespace', modifiers: [], start: 15, length: 6 }, // typing
+            { type: 'class', modifiers: [], start: 29, length: 3 }, // Any
+            { type: 'class', modifiers: [], start: 34, length: 8 }, // Callable
+            { type: 'class', modifiers: [], start: 44, length: 5 }, // Final
+            { type: 'class', modifiers: [], start: 51, length: 7 }, // TypeVar
+            // class A
+            { type: 'class', modifiers: ['declaration'], start: 67, length: 1 }, // A
+            // cvar
+            { type: 'property', modifiers: ['classMember'], start: 74, length: 4 }, // cvar
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 80, length: 3 }, // int
+            // __init__
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 97, length: 8 }, // __init__
+            { type: 'selfParameter', modifiers: ['declaration'], start: 106, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration'], start: 112, length: 1 }, // f
+            { type: 'class', modifiers: [], start: 115, length: 8 }, // Callable
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 128, length: 3 }, // int
+            { type: 'parameter', modifiers: ['declaration'], start: 134, length: 1 }, // t
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 137, length: 4 }, // type
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 142, length: 3 }, // int
+            { type: 'selfParameter', modifiers: [], start: 157, length: 4 }, // self
+            { type: 'function', modifiers: ['readonly', 'classMember'], start: 162, length: 1 }, // f
+            { type: 'class', modifiers: [], start: 165, length: 5 }, // Final
+            { type: 'class', modifiers: [], start: 171, length: 8 }, // Callable
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 184, length: 3 }, // int
+            { type: 'parameter', modifiers: [], start: 192, length: 1 }, // f
+            { type: 'selfParameter', modifiers: [], start: 202, length: 4 }, // self
+            { type: 'class', modifiers: ['classMember', 'defaultLibrary', 'builtin'], start: 207, length: 1 }, // t
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 210, length: 4 }, // type
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 215, length: 3 }, // int
+            { type: 'parameter', modifiers: [], start: 222, length: 1 }, // t
+            // b
+            { type: 'property', modifiers: ['declaration', 'classMember'], start: 247, length: 1 }, // b
+            { type: 'decorator', modifiers: [], start: 229, length: 1 }, // @
+            { type: 'decorator', modifiers: [], start: 230, length: 8 }, // property
+            { type: 'selfParameter', modifiers: ['declaration'], start: 249, length: 4 }, // self
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 258, length: 3 }, // int
+            { type: 'selfParameter', modifiers: [], start: 278, length: 4 }, // self
+            { type: 'function', modifiers: ['readonly', 'classMember'], start: 283, length: 1 }, // f
+            // b.setter
+            { type: 'property', modifiers: ['declaration', 'classMember'], start: 310, length: 1 }, // b
+            { type: 'decorator', modifiers: [], start: 292, length: 1 }, // @
+            { type: 'property', modifiers: ['classMember'], start: 293, length: 1 }, // b
+            { type: 'method', modifiers: ['classMember'], start: 295, length: 6 }, // setter
+            { type: 'selfParameter', modifiers: ['declaration'], start: 312, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration'], start: 318, length: 5 }, // value
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 325, length: 3 }, // int
+            // d
+            { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 379, length: 1 }, // d
+            { type: 'decorator', modifiers: [], start: 357, length: 1 }, // @
+            { type: 'decorator', modifiers: [], start: 358, length: 12 }, // staticmethod
+            { type: 'parameter', modifiers: ['declaration'], start: 381, length: 1 }, // i
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 384, length: 3 }, // int
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 392, length: 5 }, // float
+            { type: 'parameter', modifiers: [], start: 414, length: 1 }, // i
+            // __getattr__
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 431, length: 11 }, // __getattr__
+            { type: 'selfParameter', modifiers: ['declaration'], start: 443, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration'], start: 449, length: 4 }, // name
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 455, length: 3 }, // str
+            { type: 'class', modifiers: [], start: 463, length: 8 }, // Callable
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 476, length: 5 }, // float
+            // ufun0
+            { type: 'function', modifiers: ['declaration'], start: 517, length: 5 }, // ufun0
+            { type: 'parameter', modifiers: ['declaration'], start: 523, length: 1 }, // a
+            { type: 'parameter', modifiers: [], start: 531, length: 1 }, // a
+            { type: 'parameter', modifiers: [], start: 535, length: 1 }, // a
+            // ufun1
+            { type: 'function', modifiers: ['declaration'], start: 555, length: 5 }, // ufun1
+            { type: 'parameter', modifiers: ['declaration'], start: 561, length: 1 }, // b
+            { type: 'class', modifiers: [], start: 564, length: 3 }, // Any
+            { type: 'class', modifiers: [], start: 572, length: 3 }, // Any
+            { type: 'parameter', modifiers: [], start: 588, length: 1 }, // b
+            // a = A(lambda: int(A.d(3)), int)
+            { type: 'variable', modifiers: [], start: 611, length: 1 }, // a
+            { type: 'class', modifiers: [], start: 615, length: 1 }, // A
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 625, length: 3 }, // int
+            { type: 'class', modifiers: [], start: 629, length: 1 }, // A
+            { type: 'method', modifiers: ['static', 'classMember'], start: 631, length: 1 }, // d
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 638, length: 3 }, // int
+            // print(a.b, a.f, os.path.pardir)
+            { type: 'function', modifiers: ['defaultLibrary', 'builtin'], start: 643, length: 5 }, // print
+            { type: 'variable', modifiers: [], start: 649, length: 1 }, // a
+            { type: 'property', modifiers: ['classMember'], start: 651, length: 1 }, // b
+            { type: 'variable', modifiers: [], start: 654, length: 1 }, // a
+            { type: 'function', modifiers: ['readonly', 'classMember'], start: 656, length: 1 }, // f
+            { type: 'namespace', modifiers: [], start: 659, length: 2 }, // os
+            { type: 'namespace', modifiers: [], start: 662, length: 4 }, // path
+            { type: 'variable', modifiers: [], start: 667, length: 6 }, // pardir
+            // c = a.t
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 675, length: 1 }, // a
+            { type: 'variable', modifiers: [], start: 679, length: 1 }, // a
+            { type: 'class', modifiers: ['classMember', 'defaultLibrary', 'builtin'], start: 681, length: 1 }, // t
+            // d: Any = a.abc()
+            { type: 'variable', modifiers: [], start: 683, length: 1 }, // d
+            { type: 'class', modifiers: [], start: 686, length: 3 }, // Any
+            { type: 'variable', modifiers: [], start: 692, length: 1 }, // a
+            { type: 'property', modifiers: ['classMember', 'readonly'], start: 694, length: 3 }, // abc
+            // A.cvar = 4 + d.is_integer()
+            { type: 'class', modifiers: [], start: 700, length: 1 }, // A
+            { type: 'property', modifiers: ['classMember'], start: 702, length: 4 }, // cvar
+            { type: 'variable', modifiers: [], start: 713, length: 1 }, // d
+            // e = ufun1(12)
+            { type: 'variable', modifiers: [], start: 728, length: 1 }, // e
+            { type: 'function', modifiers: [], start: 732, length: 5 }, // ufun1
+        ]);
+    });
+
     test('enum', () => {
         const result = semanticTokenizeSampleFile('enum.py');
         expect(result).toStrictEqual([
@@ -81,29 +192,29 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: [], start: 89, length: 5 },
             // Foo
             { type: 'class', modifiers: ['declaration'], start: 107, length: 3 },
-            { type: 'method', modifiers: ['declaration'], start: 120, length: 8 },
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 120, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 129, length: 4 },
             { type: 'selfParameter', modifiers: [], start: 144, length: 4 },
-            { type: 'property', modifiers: ['readonly'], start: 149, length: 8 },
+            { type: 'property', modifiers: ['readonly', 'classMember'], start: 149, length: 8 },
             { type: 'class', modifiers: [], start: 159, length: 5 },
-            { type: 'property', modifiers: ['declaration', 'readonly'], start: 193, length: 3 },
+            { type: 'property', modifiers: ['declaration', 'classMember', 'readonly'], start: 193, length: 3 },
             { type: 'decorator', modifiers: [], start: 175, length: 1 },
             { type: 'decorator', modifiers: [], start: 176, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 197, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 206, length: 3 },
-            { type: 'property', modifiers: ['declaration'], start: 238, length: 3 },
+            { type: 'property', modifiers: ['declaration', 'classMember'], start: 238, length: 3 },
             { type: 'decorator', modifiers: [], start: 220, length: 1 },
             { type: 'decorator', modifiers: [], start: 221, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 242, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 251, length: 3 },
-            { type: 'property', modifiers: ['declaration'], start: 284, length: 3 },
+            { type: 'property', modifiers: ['declaration', 'classMember'], start: 284, length: 3 },
             { type: 'decorator', modifiers: [], start: 264, length: 1 },
-            { type: 'property', modifiers: [], start: 265, length: 3 },
-            { type: 'method', modifiers: [], start: 269, length: 6 },
+            { type: 'property', modifiers: ['classMember'], start: 265, length: 3 },
+            { type: 'method', modifiers: ['classMember'], start: 269, length: 6 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 288, length: 4 },
             { type: 'parameter', modifiers: ['declaration'], start: 294, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 },
-            { type: 'method', modifiers: ['declaration'], start: 320, length: 11 },
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 320, length: 11 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 332, length: 4 },
             { type: 'parameter', modifiers: ['declaration'], start: 338, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 344, length: 3 },
@@ -111,17 +222,17 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
             // Bar
             { type: 'class', modifiers: ['declaration'], start: 385, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 394, length: 3 },
+            { type: 'property', modifiers: ['readonly', 'classMember'], start: 394, length: 3 },
             { type: 'class', modifiers: [], start: 399, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 405, length: 3 },
-            { type: 'method', modifiers: ['declaration'], start: 425, length: 11 },
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 425, length: 11 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 437, length: 4 },
             { type: 'parameter', modifiers: ['declaration'], start: 443, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 449, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 457, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 477, length: 3 },
             { type: 'parameter', modifiers: [], start: 481, length: 4 },
-            { type: 'method', modifiers: ['declaration'], start: 510, length: 11 },
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 510, length: 11 },
             { type: 'decorator', modifiers: [], start: 492, length: 1 },
             { type: 'decorator', modifiers: [], start: 493, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 522, length: 4 },
@@ -131,31 +242,31 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 546, length: 3 },
             // Foo().foo
             { type: 'class', modifiers: [], start: 567, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 573, length: 3 },
+            { type: 'property', modifiers: ['classMember', 'readonly'], start: 573, length: 3 },
             // Foo().bar
             { type: 'class', modifiers: [], start: 577, length: 3 },
-            { type: 'property', modifiers: [], start: 583, length: 3 },
+            { type: 'property', modifiers: ['classMember'], start: 583, length: 3 },
             // baz = Foo()
             { type: 'variable', modifiers: [], start: 588, length: 3 },
             { type: 'class', modifiers: [], start: 594, length: 3 },
             // _ = baz.foo
             { type: 'variable', modifiers: [], start: 600, length: 1 },
             { type: 'variable', modifiers: [], start: 604, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 608, length: 3 },
+            { type: 'property', modifiers: ['classMember', 'readonly'], start: 608, length: 3 },
             // meaning = baz.constant
             { type: 'variable', modifiers: [], start: 612, length: 7 },
             { type: 'variable', modifiers: [], start: 622, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 626, length: 8 },
+            { type: 'property', modifiers: ['readonly', 'classMember'], start: 626, length: 8 },
             // bam = baz.pi + Bar.fir
             { type: 'variable', modifiers: [], start: 635, length: 3 },
             { type: 'variable', modifiers: [], start: 641, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 645, length: 2 },
+            { type: 'property', modifiers: ['readonly', 'classMember'], start: 645, length: 2 },
             { type: 'class', modifiers: [], start: 650, length: 3 },
-            { type: 'property', modifiers: ['readonly'], start: 654, length: 3 },
+            { type: 'property', modifiers: ['readonly', 'classMember'], start: 654, length: 3 },
             // bar = Bar().beef
             { type: 'variable', modifiers: [], start: 658, length: 3 },
             { type: 'class', modifiers: [], start: 664, length: 3 },
-            { type: 'property', modifiers: [], start: 670, length: 4 },
+            { type: 'property', modifiers: ['classMember'], start: 670, length: 4 },
         ]);
     });
 
@@ -258,11 +369,11 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'decorator', modifiers: [], start: 124, length: 1 }, // @
             { type: 'namespace', modifiers: [], start: 125, length: 11 }, // dataclasses
             { type: 'function', modifiers: [], start: 137, length: 9 }, // dataclass
-            { type: 'method', modifiers: ['declaration'], start: 177, length: 6 }, // method
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 177, length: 6 }, // method
             { type: 'decorator', modifiers: [], start: 162, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 163, length: 5 }, // final
             { type: 'selfParameter', modifiers: ['declaration'], start: 184, length: 4 }, // self
-            { type: 'method', modifiers: ['declaration', 'static'], start: 221, length: 6 }, // static
+            { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 221, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 199, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 200, length: 12 }, // staticmethod
 
@@ -271,7 +382,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 237, length: 9 }, // functools
             { type: 'function', modifiers: [], start: 247, length: 5 }, // cache
             { type: 'class', modifiers: [], start: 272, length: 1 }, // B
-            { type: 'method', modifiers: ['static'], start: 274, length: 6 }, // static
+            { type: 'method', modifiers: ['static', 'classMember'], start: 274, length: 6 }, // static
         ]);
     });
 
@@ -280,13 +391,13 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             // method
             { type: 'class', modifiers: ['declaration'], start: 6, length: 1 }, // C
-            { type: 'method', modifiers: ['declaration'], start: 17, length: 8 }, // __init__
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 17, length: 8 }, // __init__
             { type: 'selfParameter', modifiers: ['declaration'], start: 26, length: 4 }, // self
             { type: 'parameter', modifiers: ['declaration'], start: 32, length: 1 }, // x
             { type: 'selfParameter', modifiers: [], start: 44, length: 4 }, // self
-            { type: 'property', modifiers: [], start: 49, length: 1 }, // x
+            { type: 'property', modifiers: ['classMember'], start: 49, length: 1 }, // x
             { type: 'parameter', modifiers: [], start: 53, length: 1 }, // x
-            { type: 'method', modifiers: ['declaration'], start: 81, length: 1 }, // m
+            { type: 'method', modifiers: ['declaration', 'classMember'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 61, length: 11 }, // classmethod
             { type: 'clsParameter', modifiers: ['declaration'], start: 83, length: 3 }, // cls

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -16,7 +16,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 7, length: 2 }, // os
             { type: 'namespace', modifiers: [], start: 15, length: 6 }, // typing
-            { type: 'class', modifiers: [], start: 29, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 29, length: 3 }, // Any
             { type: 'class', modifiers: [], start: 34, length: 8 }, // Callable
             { type: 'class', modifiers: [], start: 44, length: 5 }, // Final
             { type: 'class', modifiers: [], start: 51, length: 7 }, // TypeVar
@@ -27,71 +27,66 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 80, length: 3 }, // int
             // __init__
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 97, length: 8 }, // __init__
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 106, length: 4 }, // self
-            { type: 'function', modifiers: ['declaration', 'argument'], start: 112, length: 1 }, // f
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 106, length: 4 }, // self
+            { type: 'function', modifiers: ['declaration', 'parameter'], start: 112, length: 1 }, // f
             { type: 'class', modifiers: [], start: 115, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 128, length: 3 }, // int
-            {
-                type: 'class',
-                modifiers: ['declaration', 'argument', 'defaultLibrary', 'builtin'],
-                start: 134,
-                length: 1,
-            }, // t
+            { type: 'class', modifiers: ['declaration', 'parameter'], start: 134, length: 1 }, // t
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 137, length: 4 }, // type
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 142, length: 3 }, // int
-            { type: 'selfParameter', modifiers: ['argument'], start: 157, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['parameter'], start: 157, length: 4 }, // self
             { type: 'function', modifiers: ['readonly', 'classMember'], start: 162, length: 1 }, // f
             { type: 'class', modifiers: [], start: 165, length: 5 }, // Final
             { type: 'class', modifiers: [], start: 171, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 184, length: 3 }, // int
-            { type: 'function', modifiers: ['argument'], start: 192, length: 1 }, // f
-            { type: 'selfParameter', modifiers: ['argument'], start: 202, length: 4 }, // self
-            { type: 'class', modifiers: ['classMember', 'defaultLibrary', 'builtin'], start: 207, length: 1 }, // t
+            { type: 'function', modifiers: ['parameter'], start: 192, length: 1 }, // f
+            { type: 'selfParameter', modifiers: ['parameter'], start: 202, length: 4 }, // self
+            { type: 'class', modifiers: ['classMember'], start: 207, length: 1 }, // t
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 210, length: 4 }, // type
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 215, length: 3 }, // int
-            { type: 'class', modifiers: ['argument', 'defaultLibrary', 'builtin'], start: 222, length: 1 }, // t
+            { type: 'class', modifiers: ['parameter'], start: 222, length: 1 }, // t
             // b
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 247, length: 1 }, // b
             { type: 'decorator', modifiers: [], start: 229, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 230, length: 8 }, // property
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 249, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 249, length: 4 }, // self
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 258, length: 3 }, // int
-            { type: 'selfParameter', modifiers: ['argument'], start: 278, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['parameter'], start: 278, length: 4 }, // self
             { type: 'function', modifiers: ['readonly', 'classMember'], start: 283, length: 1 }, // f
             // b.setter
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 310, length: 1 }, // b
             { type: 'decorator', modifiers: [], start: 292, length: 1 }, // @
             { type: 'property', modifiers: ['classMember'], start: 293, length: 1 }, // b
             { type: 'method', modifiers: ['classMember'], start: 295, length: 6 }, // setter
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 312, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 318, length: 5 }, // value
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 312, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 318, length: 5 }, // value
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 325, length: 3 }, // int
             // d
             { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 379, length: 1 }, // d
             { type: 'decorator', modifiers: [], start: 357, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 358, length: 12 }, // staticmethod
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 381, length: 1 }, // i
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 381, length: 1 }, // i
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 384, length: 3 }, // int
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 392, length: 5 }, // float
-            { type: 'parameter', modifiers: ['argument'], start: 414, length: 1 }, // i
+            { type: 'parameter', modifiers: ['parameter'], start: 414, length: 1 }, // i
             // __getattr__
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 431, length: 11 }, // __getattr__
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 443, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 449, length: 4 }, // name
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 443, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 449, length: 4 }, // name
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 455, length: 3 }, // str
             { type: 'class', modifiers: [], start: 463, length: 8 }, // Callable
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 476, length: 5 }, // float
             // ufun0
             { type: 'function', modifiers: ['declaration'], start: 517, length: 5 }, // ufun0
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 523, length: 1 }, // a
-            { type: 'parameter', modifiers: ['argument'], start: 531, length: 1 }, // a
-            { type: 'parameter', modifiers: ['argument'], start: 535, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 523, length: 1 }, // a
+            { type: 'parameter', modifiers: ['parameter'], start: 531, length: 1 }, // a
+            { type: 'parameter', modifiers: ['parameter'], start: 535, length: 1 }, // a
             // ufun1
             { type: 'function', modifiers: ['declaration'], start: 555, length: 5 }, // ufun1
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 561, length: 1 }, // b
-            { type: 'class', modifiers: [], start: 564, length: 3 }, // Any
-            { type: 'class', modifiers: [], start: 572, length: 3 }, // Any
-            { type: 'parameter', modifiers: ['argument'], start: 588, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 561, length: 1 }, // b
+            { type: 'type', modifiers: [], start: 564, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 572, length: 3 }, // Any
+            { type: 'parameter', modifiers: ['parameter'], start: 588, length: 1 }, // b
             // a = A(lambda: int(A.d(3)), int)
             { type: 'variable', modifiers: [], start: 611, length: 1 }, // a
             { type: 'class', modifiers: [], start: 615, length: 1 }, // A
@@ -109,12 +104,12 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 662, length: 4 }, // path
             { type: 'variable', modifiers: [], start: 667, length: 6 }, // pardir
             // c = a.t
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 675, length: 1 }, // a
+            { type: 'class', modifiers: [], start: 675, length: 1 }, // a
             { type: 'variable', modifiers: [], start: 679, length: 1 }, // a
-            { type: 'class', modifiers: ['classMember', 'defaultLibrary', 'builtin'], start: 681, length: 1 }, // t
+            { type: 'class', modifiers: ['classMember'], start: 681, length: 1 }, // t
             // d: Any = a.abc()
             { type: 'variable', modifiers: [], start: 683, length: 1 }, // d
-            { type: 'class', modifiers: [], start: 686, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 686, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 692, length: 1 }, // a
             { type: 'function', modifiers: ['classMember', 'readonly'], start: 694, length: 3 }, // abc
             // A.cvar = 4 + d.is_integer()
@@ -170,7 +165,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'function', modifiers: [], start: 111, length: 1 }, // s
             { type: 'variable', modifiers: ['readonly'], start: 114, length: 10 }, // IGNORECASE
             { type: 'namespace', modifiers: [], start: 130, length: 6 }, // typing
-            { type: 'class', modifiers: [], start: 144, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 144, length: 5 }, // Never
             { type: 'class', modifiers: [], start: 151, length: 8 }, // Iterable
             { type: 'class', modifiers: [], start: 163, length: 3 }, // Foo
             { type: 'namespace', modifiers: [], start: 172, length: 11 }, // collections
@@ -198,30 +193,30 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             // Foo
             { type: 'class', modifiers: ['declaration'], start: 107, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 120, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 129, length: 4 },
-            { type: 'selfParameter', modifiers: ['argument'], start: 144, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 129, length: 4 },
+            { type: 'selfParameter', modifiers: ['parameter'], start: 144, length: 4 },
             { type: 'property', modifiers: ['readonly', 'classMember'], start: 149, length: 8 },
             { type: 'class', modifiers: [], start: 159, length: 5 },
             { type: 'property', modifiers: ['declaration', 'classMember', 'readonly'], start: 193, length: 3 },
             { type: 'decorator', modifiers: [], start: 175, length: 1 },
             { type: 'decorator', modifiers: [], start: 176, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 197, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 197, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 206, length: 3 },
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 238, length: 3 },
             { type: 'decorator', modifiers: [], start: 220, length: 1 },
             { type: 'decorator', modifiers: [], start: 221, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 242, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 242, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 251, length: 3 },
             { type: 'property', modifiers: ['declaration', 'classMember'], start: 284, length: 3 },
             { type: 'decorator', modifiers: [], start: 264, length: 1 },
             { type: 'property', modifiers: ['classMember'], start: 265, length: 3 },
             { type: 'method', modifiers: ['classMember'], start: 269, length: 6 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 288, length: 4 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 294, length: 5 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 288, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 294, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 320, length: 11 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 332, length: 4 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 338, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 332, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 338, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 344, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 352, length: 5 },
             { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
@@ -231,19 +226,19 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: [], start: 399, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 405, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 425, length: 11 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 437, length: 4 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 443, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 437, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 443, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 449, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 457, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 477, length: 3 },
-            { type: 'parameter', modifiers: ['argument'], start: 481, length: 4 },
+            { type: 'parameter', modifiers: ['parameter'], start: 481, length: 4 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 510, length: 11 },
             { type: 'decorator', modifiers: [], start: 492, length: 1 },
             { type: 'decorator', modifiers: [], start: 493, length: 8 },
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 522, length: 4 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 528, length: 4 },
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 522, length: 4 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 528, length: 4 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 534, length: 3 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 539, length: 5 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 539, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 546, length: 3 },
             // Foo().foo
             { type: 'class', modifiers: [], start: 567, length: 3 },
@@ -279,24 +274,24 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('never.py');
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
-            { type: 'class', modifiers: [], start: 19, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 19, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 26, length: 3 }, // foo
-            { type: 'class', modifiers: [], start: 31, length: 5 }, // Never
-            { type: 'class', modifiers: [], start: 37, length: 3 }, // bar
-            { type: 'class', modifiers: [], start: 43, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 31, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 37, length: 3 }, // bar
+            { type: 'type', modifiers: [], start: 43, length: 5 }, // Never
             { type: 'function', modifiers: ['declaration'], start: 54, length: 3 }, // baz
-            { type: 'class', modifiers: [], start: 63, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 63, length: 5 }, // Never
             { type: 'function', modifiers: ['declaration'], start: 83, length: 4 }, // asdf
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 88, length: 3 }, // foo
-            { type: 'class', modifiers: [], start: 93, length: 5 }, // Never
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 88, length: 3 }, // foo
+            { type: 'type', modifiers: [], start: 93, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 105, length: 5 }, // value
-            { type: 'class', modifiers: [], start: 112, length: 5 }, // Never
-            { type: 'parameter', modifiers: ['argument'], start: 120, length: 3 }, // foo
+            { type: 'type', modifiers: [], start: 112, length: 5 }, // Never
+            { type: 'parameter', modifiers: ['parameter'], start: 120, length: 3 }, // foo
             { type: 'variable', modifiers: [], start: 128, length: 5 }, // value
-            { type: 'class', modifiers: [], start: 135, length: 4 }, // Type
-            { type: 'class', modifiers: [], start: 142, length: 5 }, // Never
+            { type: 'type', modifiers: [], start: 135, length: 4 }, // Type
+            { type: 'type', modifiers: [], start: 142, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 148, length: 5 }, // value
-            { type: 'class', modifiers: [], start: 155, length: 4 }, // Type
+            { type: 'type', modifiers: [], start: 155, length: 4 }, // Type
             { type: 'function', modifiers: ['declaration'], start: 169, length: 8 }, // inferred
             { type: 'variable', modifiers: [], start: 185, length: 5 }, // value
             { type: 'function', modifiers: ['defaultLibrary', 'builtin'], start: 207, length: 10 }, // isinstance
@@ -311,8 +306,8 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 315, length: 6 }, // value2
             { type: 'keyword', modifiers: [], start: 323, length: 4 }, // type
             { type: 'type', modifiers: [], start: 328, length: 3 }, // Baz
-            { type: 'class', modifiers: [], start: 334, length: 5 }, // Never
-            { type: 'function', modifiers: [], start: 340, length: 3 }, // baz
+            { type: 'type', modifiers: [], start: 334, length: 5 }, // Never
+            { type: 'variable', modifiers: [], start: 340, length: 3 }, // bat
             { type: 'type', modifiers: [], start: 345, length: 3 }, // Baz
         ]);
     });
@@ -323,10 +318,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 5, length: 6 },
             { type: 'class', modifiers: [], start: 19, length: 8 },
             { type: 'function', modifiers: ['declaration'], start: 34, length: 3 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 38, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 38, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 47, length: 1 },
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 52, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 47, length: 1 },
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 52, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 58, length: 3 },
             { type: 'function', modifiers: [], start: 72, length: 3 },
             { type: 'type', modifiers: [], start: 79, length: 3 },
@@ -343,16 +338,16 @@ if (process.platform !== 'win32' || !process.env['CI']) {
     test('type_aliases', () => {
         const result = semanticTokenizeSampleFile('type_aliases.py');
         expect(result).toStrictEqual([
-            { type: 'namespace', modifiers: [], start: 5, length: 6 },
-            { type: 'class', modifiers: [], start: 19, length: 9 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 30, length: 3 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 36, length: 3 },
-            { type: 'class', modifiers: [], start: 40, length: 3 },
-            { type: 'class', modifiers: [], start: 45, length: 9 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 57, length: 3 },
-            { type: 'keyword', modifiers: [], start: 61, length: 4 },
-            { type: 'class', modifiers: [], start: 66, length: 3 },
-            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 72, length: 3 },
+            { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
+            { type: 'class', modifiers: [], start: 19, length: 9 }, // TypeAlias
+            { type: 'class', modifiers: [], start: 30, length: 3 }, // Foo
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 36, length: 3 }, // int
+            { type: 'class', modifiers: [], start: 40, length: 3 }, // Bar
+            { type: 'class', modifiers: [], start: 45, length: 9 }, // TypeAlias
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 57, length: 3 }, // int
+            { type: 'keyword', modifiers: [], start: 61, length: 4 }, // type
+            { type: 'class', modifiers: [], start: 66, length: 3 }, // Baz
+            { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 72, length: 3 }, // int
         ]);
     });
 
@@ -377,7 +372,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 177, length: 6 }, // method
             { type: 'decorator', modifiers: [], start: 162, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 163, length: 5 }, // final
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 184, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 184, length: 4 }, // self
             { type: 'method', modifiers: ['declaration', 'static', 'classMember'], start: 221, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 199, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 200, length: 12 }, // staticmethod
@@ -397,34 +392,34 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             // method
             { type: 'class', modifiers: ['declaration'], start: 6, length: 1 }, // C
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 17, length: 8 }, // __init__
-            { type: 'selfParameter', modifiers: ['declaration', 'argument'], start: 26, length: 4 }, // self
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 32, length: 1 }, // x
-            { type: 'selfParameter', modifiers: ['argument'], start: 44, length: 4 }, // self
+            { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 26, length: 4 }, // self
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 32, length: 1 }, // x
+            { type: 'selfParameter', modifiers: ['parameter'], start: 44, length: 4 }, // self
             { type: 'property', modifiers: ['classMember'], start: 49, length: 1 }, // x
-            { type: 'parameter', modifiers: ['argument'], start: 53, length: 1 }, // x
+            { type: 'parameter', modifiers: ['parameter'], start: 53, length: 1 }, // x
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
             { type: 'decorator', modifiers: [], start: 61, length: 11 }, // classmethod
-            { type: 'clsParameter', modifiers: ['declaration', 'argument'], start: 83, length: 3 }, // cls
-            { type: 'clsParameter', modifiers: ['argument'], start: 104, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['declaration', 'parameter'], start: 83, length: 3 }, // cls
+            { type: 'clsParameter', modifiers: ['parameter'], start: 104, length: 3 }, // cls
             // function
             { type: 'function', modifiers: ['declaration'], start: 116, length: 1 }, // f
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 118, length: 1 }, // x
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 121, length: 1 }, // y
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 118, length: 1 }, // x
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 121, length: 1 }, // y
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 124, length: 3 }, // int
             { type: 'function', modifiers: ['declaration'], start: 138, length: 1 }, // g
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 140, length: 1 }, // x
-            { type: 'parameter', modifiers: ['argument'], start: 159, length: 1 }, // x
-            { type: 'parameter', modifiers: ['argument'], start: 163, length: 1 }, // y
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 140, length: 1 }, // x
+            { type: 'parameter', modifiers: ['parameter'], start: 159, length: 1 }, // x
+            { type: 'parameter', modifiers: ['parameter'], start: 163, length: 1 }, // y
             { type: 'variable', modifiers: [], start: 169, length: 1 }, // z
-            { type: 'parameter', modifiers: ['argument'], start: 177, length: 1 }, // x
+            { type: 'parameter', modifiers: ['parameter'], start: 177, length: 1 }, // x
             { type: 'function', modifiers: [], start: 190, length: 1 }, // g
             { type: 'variable', modifiers: [], start: 192, length: 1 }, // z
             // lambda
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 203, length: 1 }, // a
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 206, length: 1 }, // b
-            { type: 'parameter', modifiers: ['argument'], start: 209, length: 1 }, // a
-            { type: 'parameter', modifiers: ['argument'], start: 213, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 203, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 206, length: 1 }, // b
+            { type: 'parameter', modifiers: ['parameter'], start: 209, length: 1 }, // a
+            { type: 'parameter', modifiers: ['parameter'], start: 213, length: 1 }, // b
         ]);
     });
 
@@ -432,24 +427,24 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('unknown.py');
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
-            { type: 'class', modifiers: [], start: 19, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 19, length: 3 }, // Any
             { type: 'function', modifiers: ['declaration'], start: 28, length: 1 }, // f
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 30, length: 1 }, // l
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 30, length: 1 }, // l
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 33, length: 4 }, // list
-            { type: 'class', modifiers: [], start: 42, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 42, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 51, length: 1 }, // v
-            { type: 'parameter', modifiers: ['argument'], start: 55, length: 1 }, // l
+            { type: 'parameter', modifiers: ['parameter'], start: 55, length: 1 }, // l
             { type: 'variable', modifiers: [], start: 71, length: 1 }, // v
             { type: 'function', modifiers: ['declaration'], start: 79, length: 2 }, // f1
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 82, length: 1 }, // a
-            { type: 'parameter', modifiers: ['argument'], start: 90, length: 1 }, // a
-            { type: 'parameter', modifiers: ['argument'], start: 94, length: 1 }, // a
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 82, length: 1 }, // a
+            { type: 'parameter', modifiers: ['parameter'], start: 90, length: 1 }, // a
+            { type: 'parameter', modifiers: ['parameter'], start: 94, length: 1 }, // a
             // `T` and `maximum` should be ignored
             { type: 'function', modifiers: ['declaration'], start: 114, length: 2 }, // f2
-            { type: 'parameter', modifiers: ['declaration', 'argument'], start: 117, length: 1 }, // b
-            { type: 'class', modifiers: [], start: 120, length: 3 }, // Any
-            { type: 'class', modifiers: [], start: 128, length: 3 }, // Any
-            { type: 'parameter', modifiers: ['argument'], start: 144, length: 1 }, // b
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 117, length: 1 }, // b
+            { type: 'type', modifiers: [], start: 120, length: 3 }, // Any
+            { type: 'type', modifiers: [], start: 128, length: 3 }, // Any
+            { type: 'parameter', modifiers: ['parameter'], start: 144, length: 1 }, // b
             // `as_integer_ratio`, `g`, and `foo` should be ignored
             { type: 'variable', modifiers: [], start: 174, length: 3 }, // bar
             { type: 'function', modifiers: [], start: 180, length: 1 }, // f
@@ -474,7 +469,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 { type: 'class', modifiers: [], start: 25, length: 3 }, // Set
                 { type: 'class', modifiers: [], start: 30, length: 9 }, // TypeAlias
                 // type aliases
-                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 }, // Foo
+                { type: 'class', modifiers: [], start: 41, length: 3 }, // Foo
                 { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 47, length: 4 }, // list
                 { type: 'type', modifiers: [], start: 52, length: 3 }, // Bar
                 { type: 'class', modifiers: [], start: 58, length: 4 }, // List

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -104,7 +104,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'namespace', modifiers: [], start: 662, length: 4 }, // path
             { type: 'variable', modifiers: [], start: 667, length: 6 }, // pardir
             // c = a.t
-            { type: 'class', modifiers: [], start: 675, length: 1 }, // a
+            { type: 'class', modifiers: [], start: 675, length: 1 }, // c
             { type: 'variable', modifiers: [], start: 679, length: 1 }, // a
             { type: 'class', modifiers: ['classMember'], start: 681, length: 1 }, // t
             // d: Any = a.abc()

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -23,7 +23,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             // class A
             { type: 'class', modifiers: ['declaration'], start: 67, length: 1 }, // A
             // cvar
-            { type: 'property', modifiers: ['classMember'], start: 74, length: 4 }, // cvar
+            { type: 'property', modifiers: ['classMember', 'static'], start: 74, length: 4 }, // cvar
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 80, length: 3 }, // int
             // __init__
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 97, length: 8 }, // __init__
@@ -111,10 +111,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 683, length: 1 }, // d
             { type: 'class', modifiers: [], start: 686, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 692, length: 1 }, // a
-            { type: 'property', modifiers: ['classMember', 'readonly'], start: 694, length: 3 }, // abc
+            { type: 'function', modifiers: ['classMember', 'readonly'], start: 694, length: 3 }, // abc
             // A.cvar = 4 + d.is_integer()
             { type: 'class', modifiers: [], start: 700, length: 1 }, // A
-            { type: 'property', modifiers: ['classMember'], start: 702, length: 4 }, // cvar
+            { type: 'property', modifiers: ['classMember', 'static'], start: 702, length: 4 }, // cvar
             { type: 'variable', modifiers: [], start: 713, length: 1 }, // d
             // e = ufun1(12)
             { type: 'variable', modifiers: [], start: 728, length: 1 }, // e
@@ -222,7 +222,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
             // Bar
             { type: 'class', modifiers: ['declaration'], start: 385, length: 3 },
-            { type: 'property', modifiers: ['readonly', 'classMember'], start: 394, length: 3 },
+            { type: 'property', modifiers: ['readonly', 'classMember', 'static'], start: 394, length: 3 },
             { type: 'class', modifiers: [], start: 399, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 405, length: 3 },
             { type: 'method', modifiers: ['declaration', 'classMember'], start: 425, length: 11 },
@@ -262,7 +262,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'variable', modifiers: [], start: 641, length: 3 },
             { type: 'property', modifiers: ['readonly', 'classMember'], start: 645, length: 2 },
             { type: 'class', modifiers: [], start: 650, length: 3 },
-            { type: 'property', modifiers: ['readonly', 'classMember'], start: 654, length: 3 },
+            { type: 'property', modifiers: ['readonly', 'classMember', 'static'], start: 654, length: 3 },
             // bar = Bar().beef
             { type: 'variable', modifiers: [], start: 658, length: 3 },
             { type: 'class', modifiers: [], start: 664, length: 3 },

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -194,10 +194,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 }, // str
             { type: 'variable', modifiers: [], start: 315, length: 6 }, // value2
             { type: 'keyword', modifiers: [], start: 323, length: 4 }, // type
-            { type: 'class', modifiers: [], start: 328, length: 3 }, // Baz
+            { type: 'type', modifiers: [], start: 328, length: 3 }, // Baz
             { type: 'class', modifiers: [], start: 334, length: 5 }, // Never
             { type: 'function', modifiers: [], start: 340, length: 3 }, // baz
-            { type: 'class', modifiers: [], start: 345, length: 3 }, // Baz
+            { type: 'type', modifiers: [], start: 345, length: 3 }, // Baz
         ]);
     });
 
@@ -213,7 +213,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'parameter', modifiers: ['declaration'], start: 52, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 58, length: 3 },
             { type: 'function', modifiers: [], start: 72, length: 3 },
-            { type: 'class', modifiers: [], start: 79, length: 3 },
+            { type: 'type', modifiers: [], start: 79, length: 3 },
             { type: 'class', modifiers: [], start: 85, length: 8 },
             { type: 'function', modifiers: [], start: 105, length: 3 },
             { type: 'class', modifiers: [], start: 110, length: 8 },
@@ -360,7 +360,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 // type aliases
                 { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 }, // Foo
                 { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 47, length: 4 }, // list
-                { type: 'class', modifiers: [], start: 52, length: 3 }, // Bar
+                { type: 'type', modifiers: [], start: 52, length: 3 }, // Bar
                 { type: 'class', modifiers: [], start: 58, length: 4 }, // List
                 { type: 'class', modifiers: [], start: 65, length: 3 }, // Set
                 { type: 'class', modifiers: [], start: 69, length: 3 }, // Old

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -54,7 +54,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'function', modifiers: [], start: 111, length: 1 }, // s
             { type: 'variable', modifiers: ['readonly'], start: 114, length: 10 }, // IGNORECASE
             { type: 'namespace', modifiers: [], start: 130, length: 6 }, // typing
-            { type: 'type', modifiers: [], start: 144, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 144, length: 5 }, // Never
             { type: 'class', modifiers: [], start: 151, length: 8 }, // Iterable
             { type: 'class', modifiers: [], start: 163, length: 3 }, // Foo
             { type: 'namespace', modifiers: [], start: 172, length: 11 }, // collections
@@ -66,24 +66,27 @@ if (process.platform !== 'win32' || !process.env['CI']) {
     test('final', () => {
         const result = semanticTokenizeSampleFile('final.py');
         expect(result).toStrictEqual([
+            // imports
             { type: 'namespace', modifiers: [], start: 5, length: 4 },
             { type: 'variable', modifiers: ['readonly'], start: 17, length: 2 },
             { type: 'namespace', modifiers: [], start: 25, length: 6 },
             { type: 'class', modifiers: [], start: 39, length: 5 },
             { type: 'function', modifiers: [], start: 46, length: 8 },
+            // variable definitions
             { type: 'variable', modifiers: ['readonly'], start: 56, length: 3 },
             { type: 'variable', modifiers: ['readonly'], start: 64, length: 3 },
             { type: 'class', modifiers: [], start: 69, length: 5 },
             { type: 'variable', modifiers: [], start: 79, length: 1 },
             { type: 'variable', modifiers: ['readonly'], start: 85, length: 2 },
             { type: 'class', modifiers: [], start: 89, length: 5 },
+            // Foo
             { type: 'class', modifiers: ['declaration'], start: 107, length: 3 },
             { type: 'method', modifiers: ['declaration'], start: 120, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 129, length: 4 },
             { type: 'selfParameter', modifiers: [], start: 144, length: 4 },
             { type: 'property', modifiers: ['readonly'], start: 149, length: 8 },
             { type: 'class', modifiers: [], start: 159, length: 5 },
-            { type: 'property', modifiers: ['declaration'], start: 193, length: 3 },
+            { type: 'property', modifiers: ['declaration', 'readonly'], start: 193, length: 3 },
             { type: 'decorator', modifiers: [], start: 175, length: 1 },
             { type: 'decorator', modifiers: [], start: 176, length: 8 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 197, length: 4 },
@@ -95,8 +98,8 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 251, length: 3 },
             { type: 'property', modifiers: ['declaration'], start: 284, length: 3 },
             { type: 'decorator', modifiers: [], start: 264, length: 1 },
-            { type: 'property', modifiers: ['readonly'], start: 265, length: 3 },
-            { type: 'function', modifiers: [], start: 269, length: 6 },
+            { type: 'property', modifiers: [], start: 265, length: 3 },
+            { type: 'method', modifiers: [], start: 269, length: 6 },
             { type: 'selfParameter', modifiers: ['declaration'], start: 288, length: 4 },
             { type: 'parameter', modifiers: ['declaration'], start: 294, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 },
@@ -106,6 +109,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 344, length: 3 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 352, length: 5 },
             { type: 'variable', modifiers: ['readonly'], start: 374, length: 2 },
+            // Bar
             { type: 'class', modifiers: ['declaration'], start: 385, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 394, length: 3 },
             { type: 'class', modifiers: [], start: 399, length: 5 },
@@ -125,23 +129,30 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 534, length: 3 },
             { type: 'parameter', modifiers: ['declaration'], start: 539, length: 5 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 546, length: 3 },
+            // Foo().foo
             { type: 'class', modifiers: [], start: 567, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 573, length: 3 },
+            // Foo().bar
             { type: 'class', modifiers: [], start: 577, length: 3 },
             { type: 'property', modifiers: [], start: 583, length: 3 },
+            // baz = Foo()
             { type: 'variable', modifiers: [], start: 588, length: 3 },
             { type: 'class', modifiers: [], start: 594, length: 3 },
+            // _ = baz.foo
             { type: 'variable', modifiers: [], start: 600, length: 1 },
             { type: 'variable', modifiers: [], start: 604, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 608, length: 3 },
+            // meaning = baz.constant
             { type: 'variable', modifiers: [], start: 612, length: 7 },
             { type: 'variable', modifiers: [], start: 622, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 626, length: 8 },
+            // bam = baz.pi + Bar.fir
             { type: 'variable', modifiers: [], start: 635, length: 3 },
             { type: 'variable', modifiers: [], start: 641, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 645, length: 2 },
             { type: 'class', modifiers: [], start: 650, length: 3 },
             { type: 'property', modifiers: ['readonly'], start: 654, length: 3 },
+            // bar = Bar().beef
             { type: 'variable', modifiers: [], start: 658, length: 3 },
             { type: 'class', modifiers: [], start: 664, length: 3 },
             { type: 'property', modifiers: [], start: 670, length: 4 },
@@ -152,24 +163,24 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('never.py');
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
-            { type: 'type', modifiers: [], start: 19, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 19, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 26, length: 3 }, // foo
-            { type: 'type', modifiers: [], start: 31, length: 5 }, // Never
-            { type: 'type', modifiers: [], start: 37, length: 3 }, // bar
-            { type: 'type', modifiers: [], start: 43, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 31, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 37, length: 3 }, // bar
+            { type: 'class', modifiers: [], start: 43, length: 5 }, // Never
             { type: 'function', modifiers: ['declaration'], start: 54, length: 3 }, // baz
-            { type: 'type', modifiers: [], start: 63, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 63, length: 5 }, // Never
             { type: 'function', modifiers: ['declaration'], start: 83, length: 4 }, // asdf
             { type: 'parameter', modifiers: ['declaration'], start: 88, length: 3 }, // foo
-            { type: 'type', modifiers: [], start: 93, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 93, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 105, length: 5 }, // value
-            { type: 'type', modifiers: [], start: 112, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 112, length: 5 }, // Never
             { type: 'parameter', modifiers: [], start: 120, length: 3 }, // foo
             { type: 'variable', modifiers: [], start: 128, length: 5 }, // value
-            { type: 'type', modifiers: [], start: 135, length: 4 }, // Type
-            { type: 'type', modifiers: [], start: 142, length: 5 }, // Never
+            { type: 'class', modifiers: [], start: 135, length: 4 }, // Type
+            { type: 'class', modifiers: [], start: 142, length: 5 }, // Never
             { type: 'variable', modifiers: [], start: 148, length: 5 }, // value
-            { type: 'type', modifiers: [], start: 155, length: 4 }, // Type
+            { type: 'class', modifiers: [], start: 155, length: 4 }, // Type
             { type: 'function', modifiers: ['declaration'], start: 169, length: 8 }, // inferred
             { type: 'variable', modifiers: [], start: 185, length: 5 }, // value
             { type: 'function', modifiers: ['defaultLibrary', 'builtin'], start: 207, length: 10 }, // isinstance
@@ -183,10 +194,10 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 301, length: 3 }, // str
             { type: 'variable', modifiers: [], start: 315, length: 6 }, // value2
             { type: 'keyword', modifiers: [], start: 323, length: 4 }, // type
-            { type: 'type', modifiers: [], start: 328, length: 3 }, // Baz
-            { type: 'type', modifiers: [], start: 334, length: 5 }, // Never
-            { type: 'variable', modifiers: [], start: 340, length: 3 }, // baz
-            { type: 'type', modifiers: [], start: 345, length: 3 }, // Baz
+            { type: 'class', modifiers: [], start: 328, length: 3 }, // Baz
+            { type: 'class', modifiers: [], start: 334, length: 5 }, // Never
+            { type: 'function', modifiers: [], start: 340, length: 3 }, // baz
+            { type: 'class', modifiers: [], start: 345, length: 3 }, // Baz
         ]);
     });
 
@@ -202,7 +213,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'parameter', modifiers: ['declaration'], start: 52, length: 1 },
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 58, length: 3 },
             { type: 'function', modifiers: [], start: 72, length: 3 },
-            { type: 'type', modifiers: [], start: 79, length: 3 },
+            { type: 'class', modifiers: [], start: 79, length: 3 },
             { type: 'class', modifiers: [], start: 85, length: 8 },
             { type: 'function', modifiers: [], start: 105, length: 3 },
             { type: 'class', modifiers: [], start: 110, length: 8 },
@@ -241,7 +252,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
 
             { type: 'class', modifiers: ['declaration'], start: 116, length: 1 }, // A
             { type: 'decorator', modifiers: [], start: 97, length: 1 }, // @
-            { type: 'function', modifiers: [], start: 98, length: 9 },
+            { type: 'function', modifiers: [], start: 98, length: 9 }, // dataclass
 
             { type: 'class', modifiers: ['declaration'], start: 155, length: 1 }, // B
             { type: 'decorator', modifiers: [], start: 124, length: 1 }, // @
@@ -253,7 +264,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'selfParameter', modifiers: ['declaration'], start: 184, length: 4 }, // self
             { type: 'method', modifiers: ['declaration', 'static'], start: 221, length: 6 }, // static
             { type: 'decorator', modifiers: [], start: 199, length: 1 }, // @
-            { type: 'decorator', modifiers: [], start: 200, length: 12 },
+            { type: 'decorator', modifiers: [], start: 200, length: 12 }, // staticmethod
 
             { type: 'function', modifiers: ['declaration'], start: 257, length: 6 }, // cached
             { type: 'decorator', modifiers: [], start: 236, length: 1 }, // @
@@ -277,7 +288,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
             { type: 'parameter', modifiers: [], start: 53, length: 1 }, // x
             { type: 'method', modifiers: ['declaration'], start: 81, length: 1 }, // m
             { type: 'decorator', modifiers: [], start: 60, length: 1 }, // @
-            { type: 'decorator', modifiers: [], start: 61, length: 11 },
+            { type: 'decorator', modifiers: [], start: 61, length: 11 }, // classmethod
             { type: 'clsParameter', modifiers: ['declaration'], start: 83, length: 3 }, // cls
             { type: 'clsParameter', modifiers: [], start: 104, length: 3 }, // cls
             // function
@@ -305,17 +316,35 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         const result = semanticTokenizeSampleFile('unknown.py');
         expect(result).toStrictEqual([
             { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
-            { type: 'type', modifiers: [], start: 19, length: 3 }, // Any
+            { type: 'class', modifiers: [], start: 19, length: 3 }, // Any
             { type: 'function', modifiers: ['declaration'], start: 28, length: 1 }, // f
             { type: 'parameter', modifiers: ['declaration'], start: 30, length: 1 }, // l
             { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 33, length: 4 }, // list
-            { type: 'type', modifiers: [], start: 42, length: 3 }, // Any
+            { type: 'class', modifiers: [], start: 42, length: 3 }, // Any
             { type: 'variable', modifiers: [], start: 51, length: 1 }, // v
             { type: 'parameter', modifiers: [], start: 55, length: 1 }, // l
             { type: 'variable', modifiers: [], start: 71, length: 1 }, // v
-            // `g` and `foo` should be ignored
-            { type: 'variable', modifiers: [], start: 81, length: 3 }, // bar
-            { type: 'function', modifiers: [], start: 87, length: 1 }, // f
+            { type: 'function', modifiers: ['declaration'], start: 79, length: 2 }, // f1
+            { type: 'parameter', modifiers: ['declaration'], start: 82, length: 1 }, // a
+            { type: 'parameter', modifiers: [], start: 90, length: 1 }, // a
+            { type: 'parameter', modifiers: [], start: 94, length: 1 }, // a
+            // `T` and `maximum` should be ignored
+            { type: 'function', modifiers: ['declaration'], start: 114, length: 2 }, // f2
+            { type: 'parameter', modifiers: ['declaration'], start: 117, length: 1 }, // b
+            { type: 'class', modifiers: [], start: 120, length: 3 }, // Any
+            { type: 'class', modifiers: [], start: 128, length: 3 }, // Any
+            { type: 'parameter', modifiers: [], start: 144, length: 1 }, // b
+            // `as_integer_ratio`, `g`, and `foo` should be ignored
+            { type: 'variable', modifiers: [], start: 174, length: 3 }, // bar
+            { type: 'function', modifiers: [], start: 180, length: 1 }, // f
+            { type: 'variable', modifiers: [], start: 188, length: 1 }, // a
+            { type: 'variable', modifiers: [], start: 191, length: 1 }, // b
+            { type: 'function', modifiers: [], start: 195, length: 2 }, // f2
+            { type: 'variable', modifiers: [], start: 202, length: 1 }, // c
+            { type: 'variable', modifiers: [], start: 206, length: 1 }, // a
+            // `bit_length` should be ignored
+            { type: 'variable', modifiers: [], start: 223, length: 1 }, // b
+            // `bit_length` should be ignored
         ]);
     });
 
@@ -331,7 +360,7 @@ if (process.platform !== 'win32' || !process.env['CI']) {
                 // type aliases
                 { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 41, length: 3 }, // Foo
                 { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 47, length: 4 }, // list
-                { type: 'type', modifiers: [], start: 52, length: 3 }, // Bar
+                { type: 'class', modifiers: [], start: 52, length: 3 }, // Bar
                 { type: 'class', modifiers: [], start: 58, length: 4 }, // List
                 { type: 'class', modifiers: [], start: 65, length: 3 }, // Set
                 { type: 'class', modifiers: [], start: 69, length: 3 }, // Old


### PR DESCRIPTION
The main change introduced by this PR is to use the declarations of a given `NameNode` (if basedpyright is able to find any) as the primary source of information when determining semantic tokens instead of using the type of the `NameNode`, while using the type for refining the classification and as a fallback.
This mainly affects variables that store a type, a function, a module, etc.; for example, with the statement `x = lambda i: i + 1`, the type of `x` is a function type while the declaration is a variable declaration.
This change brings the behaviour more in line with Pylance, which appears to follow the following rules for each `NameNode` that is declared as a variable (where earlier rules take precedence over later ones):

1. If the node is declared in a class or the right-hand side of a member access, the variable is always highlighted as a `property`.
2. If the type of the node is a class type, i.e. the variable stores a class, it is highlighted as a `class`.
3. Otherwise, the variable is highlighted as a variable.

The first rule means that `property` always takes precedence in Pylance, which is replicated by this PR; however, I have modified this rule so that the right-hand side of a member access is only highlighted as a `property` if the left-hand side has a class type, which is more in line with what LSPs for other programming languages do. This also means that `path` in `import os; os.path.sep` is not highlighted as a `property`, which seems reasonable, especially since it is highlighted as `namespace` in `from os import path`.

The second rule, however, introduces an inconsistency: Variables storing a type are highlighted based on their type while everything else is not. To improve consistency, there are two options: Rule 2 could be dropped, meaning that variables are always highlighted as variables (or `property`); while this is the most consistent option, it also has undesirable side-effects even in the standard library, where `path` in `from os import path` would be highlighted as a variable. The other option, which this PR implements, is to extend rule 2 to variables containing type variables, functions, modules, or `Never`.

Many of the remaining changes deal with the side-effects of the primary transition, but there are also some deliberate changes to the behaviour:

- Highlight member accesses where the left-hand side is a class and the right-hand side is a function name as `method`. This catches situations such as the `setter` method of a property, which were highlighted as `function` before.
- Do not highlight variable names which have no declarations and whose type is unknown or any, which prevents bogus highlighting when no information to base the highlighting on is available. An alternative is the clangd approach, which is to use the `unknown` token type, but that does not seem to be better.
- For the middle part of `import … from … as …`, the type of the last part is used instead if the type of the middle part cannot be established, which occurs e.g. in `from os import path as p`.
- No longer highlight variables with names that consist of all-caps with underscores as `readonly`, since this is a very crude heuristic that falsely applies to e.g. variables representing matrices, which are often named using capital letters. Any name-based heuristic is guaranteed to produce false positives in any case.
- Highlight types as `class` consistently, as Pylance does, instead of using a hodge-podge of `class` and `type`, as basedpyright did until now.