### PR TITLE
Shortcut isEnumClassWithMembers once a single member is found

### DIFF
--- a/packages/pyright-internal/src/analyzer/enums.ts
+++ b/packages/pyright-internal/src/analyzer/enums.ts
@@ -61,26 +61,17 @@ export function isEnumClassWithMembers(evaluator: TypeEvaluator, classType: Clas
     }
 
     // Determine whether the enum class defines a member.
-    let definesMember = false;
-
-    ClassType.getSymbolTable(classType).forEach((symbol, name) => {
-        if (definesMember) {
-            // This short-circuits the forEach loop since once we've found
-            // one member, we know the answer.
-            return;
-        }
-
+    for (const name of ClassType.getSymbolTable(classType).keys()) {
         const symbolType = transformTypeForEnumMember(evaluator, classType, name);
         if (
             symbolType &&
             isClassInstance(symbolType) &&
             ClassType.isSameGenericClass(symbolType, ClassType.cloneAsInstance(classType))
         ) {
-            definesMember = true;
+            return true;
         }
-    });
-
-    return definesMember;
+    }
+    return false;
 }
 
 // Creates a new custom enum class with named values.


### PR DESCRIPTION
Fixes: https://github.com/DetachHead/basedpyright/issues/1534

Ideally  ClassType.getSymbolTable would return something that has an any() call instead of a foreach. 