### PR TITLE
feat(autoImporter): suggest import aliases from user code if explicitly re-exported

### DIFF
--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -158,9 +158,18 @@ export function buildModuleSymbolsMap(program: ProgramView, files: readonly Sour
                         continue;
                     }
 
-                    if (declaration.type === DeclarationType.Alias && isUserCode(file) && !symbol.isInDunderAll()) {
-                        // We don't include import alias in auto import
-                        // for workspace files, unless they're in '__all__'
+                    if (
+                        // We don't include import aliases in auto import for workspace files...
+                        declaration.type === DeclarationType.Alias &&
+                        isUserCode(file) &&
+                        // ... unless they're in '__all__'...
+                        !symbol.isInDunderAll() &&
+                        // ... or unless they're an 'explicit re-export' (alias with the same name, see #772)
+                        !(
+                            declaration.node.nodeType === ParseNodeType.ImportFromAs &&
+                            declaration.node.d.alias?.d.value === name
+                        )
+                    ) {
                         continue;
                     }
 

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -158,9 +158,9 @@ export function buildModuleSymbolsMap(program: ProgramView, files: readonly Sour
                         continue;
                     }
 
-                    if (declaration.type === DeclarationType.Alias && isUserCode(file)) {
+                    if (declaration.type === DeclarationType.Alias && isUserCode(file) && !symbol.isInDunderAll()) {
                         // We don't include import alias in auto import
-                        // for workspace files.
+                        // for workspace files, unless they're in '__all__'
                         continue;
                     }
 

--- a/packages/pyright-internal/src/tests/fourslash/completions.autoimport.reexports.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/completions.autoimport.reexports.fourslash.ts
@@ -1,0 +1,89 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: definitions.py
+//// def foo_function() -> None:
+////     pass
+////
+//// def bar_function() -> None:
+////     pass
+
+// @filename: reexports_with_all.py
+//// from definitions import foo_function
+//// __all__ = ["foo_function"]
+
+// @filename: reexports_with_alias.py
+//// from definitions import bar_function as bar_function
+
+// @filename: test_all.py
+//// [|/*import1*/|][|foo/*marker1*/|]
+
+// @filename: test_alias.py
+//// [|/*import2*/|][|bar/*marker2*/|]
+
+{
+    helper.openFile('/test_all.py');
+
+    const import1Range = helper.getPositionRange('import1');
+    const marker1Range = helper.getPositionRange('marker1');
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker1: {
+            completions: [
+                {
+                    label: 'foo_function',
+                    kind: Consts.CompletionItemKind.Function,
+                    documentation: '```\nfrom reexports_with_all import foo_function\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker1Range, newText: 'foo_function' },
+                    additionalTextEdits: [
+                        { range: import1Range, newText: 'from reexports_with_all import foo_function\n\n\n' },
+                    ],
+                },
+                {
+                    label: 'foo_function',
+                    kind: Consts.CompletionItemKind.Function,
+                    documentation: '```\nfrom definitions import foo_function\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker1Range, newText: 'foo_function' },
+                    additionalTextEdits: [
+                        { range: import1Range, newText: 'from definitions import foo_function\n\n\n' },
+                    ],
+                },
+            ],
+        },
+    });
+
+    helper.openFile('/test_alias.py');
+
+    const import2Range = helper.getPositionRange('import2');
+    const marker2Range = helper.getPositionRange('marker2');
+
+    // @ts-ignore
+    await helper.verifyCompletion('included', 'markdown', {
+        marker2: {
+            completions: [
+                {
+                    label: 'bar_function',
+                    kind: Consts.CompletionItemKind.Function,
+                    documentation: '```\nfrom reexports_with_alias import bar_function\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker2Range, newText: 'bar_function' },
+                    additionalTextEdits: [
+                        { range: import2Range, newText: 'from reexports_with_alias import bar_function\n\n\n' },
+                    ],
+                },
+                {
+                    label: 'bar_function',
+                    kind: Consts.CompletionItemKind.Function,
+                    documentation: '```\nfrom definitions import bar_function\n```',
+                    detail: 'Auto-import',
+                    textEdit: { range: marker2Range, newText: 'bar_function' },
+                    additionalTextEdits: [
+                        { range: import2Range, newText: 'from definitions import bar_function\n\n\n' },
+                    ],
+                },
+            ],
+        },
+    });
+}


### PR DESCRIPTION
fixes #772
### Why

We often use this pattern in our monorepo:

Given this structure:

```
components
├── __init__.py
└── foo
    ├── __init__.py
    ├── internal
    │   ├── __init__.py
    │   └── something_internal.py
    └── public
        ├── __init__.py
        └── something_public.py
```

We'll implement some symbols (functions, types, etc.) in `internal/something_internal.py`, while re-exporting them in `public/something_public.py`, with the idea that other components will import things from the `public/` folder.

```python
# components/foo/internal/something_internal.py
def my_foo_function() -> None:
    pass


# components/foo/public/something_public.py
from components.foo.internal.something_internal import my_foo_function

__all__ = ["my_foo_function"]


# Usage elsewhere
from components.foo.public.something_public import my_foo_function  # <== import is from the 'public' part

my_foo_function()
```

One issue with this pattern with BasedPyright is that auto-import completion will only provide a suggestion for the `internal/`, **not the re-export from `public/`**, which means we have to manually tweak our imports after our linters complain.

### The fix

I found the condition that was excluding these symbols and relaxed it in case the "import alias" symbol is in the `__all__`. And we now have the re-export *and* the original definition in auto-import suggestions ✨ 

<img width="917" height="107" alt="Capture d’écran 2025-10-01 à 16 15 03" src="https://github.com/user-attachments/assets/378aece7-59a5-417c-b2cd-a9b0a2ec716d" />

Even if I'm not sure this is a 100% canonical Python pattern, having an imported symbol in the `__all__` sounds like a strong signal that the developer *wants* the imported symbol to be "exposed"/"re-exported".

This PR also fixes importing re-exports done with the `from xyz import foo as foo` pattern (#772)
