### PR TITLE
Type-based descriptor instance highlighting

### DIFF
--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -15,6 +15,7 @@ import {
     isUnknown,
     NeverType,
     OverloadedType,
+    PropertyMethodInfo,
     Type,
     TypeBase,
     TypeCategory,
@@ -38,8 +39,8 @@ import { ScopeType } from './scope';
 import { assertNever } from '../common/debug';
 import { getDeclaration } from './analyzerNodeInfo';
 import { isDeclInEnumClass } from './enums';
-import { getEnclosingClass } from './parseTreeUtils';
-import { ClassMember, MemberAccessFlags, isMaybeDescriptorInstance, lookUpClassMember } from './typeUtils';
+import { getEnclosingClass, isWriteAccess } from './parseTreeUtils';
+import { ClassMember, MemberAccessFlags, isMaybeDescriptorInstance, isProperty, lookUpClassMember } from './typeUtils';
 
 type TokenTypes = SemanticTokenTypes | CustomSemanticTokenTypes;
 type TokenModifiers = SemanticTokenModifiers | CustomSemanticTokenModifiers;
@@ -512,10 +513,16 @@ export class SemanticTokensWalker extends ParseTreeWalker {
     // Check whether “decl” has a property type and does not contain fset information
     private _missingPropertySetter(decl: Declaration): boolean {
         const type = this._evaluator.getTypeForDeclaration(decl).type;
-        if (type?.category === TypeCategory.Class && ClassType.isPropertyClass(type)) {
-            return !type.priv.fsetInfo;
+        return !!type && isClass(type) && ClassType.isPropertyClass(type) && !type.priv.fsetInfo;
+    }
+
+    // Get the `fget`/`fset` information (depending on `isWriteAccess`) if `decl` is a property declaration
+    private _getPropertyInfo(decl: Declaration, isWriteAccess: boolean): PropertyMethodInfo | undefined {
+        const type = this._evaluator.getTypeForDeclaration(decl).type;
+        if (type && isClass(type) && ClassType.isPropertyClass(type)) {
+            return isWriteAccess ? type.priv.fsetInfo : type.priv.fgetInfo;
         }
-        return false;
+        return undefined;
     }
 
     private _visitFunctionWithType(node: NameNode, type: FunctionType, declarations: Declaration[]) {
@@ -530,7 +537,7 @@ export class SemanticTokensWalker extends ParseTreeWalker {
         declarations: Declaration[],
         functionType: FunctionType | undefined,
         modifiers: TokenModifiers[]
-    ): SemanticTokenTypes {
+    ): TokenTypes {
         // type alias to Callable
         if (functionType && !TypeBase.isInstance(functionType)) {
             return SemanticTokenTypes.class;
@@ -548,14 +555,69 @@ export class SemanticTokensWalker extends ParseTreeWalker {
                 modifiers.push(CustomSemanticTokenModifiers.classMember);
 
                 const declaredType = this._evaluator.getTypeForDeclaration(decl)?.type;
-                // the canonical check for properties (used e.g. in the hover message)
-                if (declaredType && isMaybeDescriptorInstance(declaredType)) {
-                    if (declarations.every((d) => this._missingPropertySetter(d))) {
-                        modifiers.push(SemanticTokenModifiers.readonly);
-                    }
-                    return SemanticTokenTypes.property;
+
+                // if there is no type information or it is not (potentially) a descriptor instance,
+                // use the default `method` token type
+                if (!declaredType || !isMaybeDescriptorInstance(declaredType)) {
+                    return SemanticTokenTypes.method;
                 }
-                return SemanticTokenTypes.method;
+
+                const isProp = isProperty(declaredType);
+                // if the descriptor instance is a property, check the declarations for `fset` information
+                // if it is not a property, use a check for the presence of `__set__`
+                const isReadOnly = isProp
+                    ? declarations.every((d) => this._missingPropertySetter(d))
+                    : !isMaybeDescriptorInstance(declaredType, true);
+                if (isReadOnly) {
+                    modifiers.push(SemanticTokenModifiers.readonly);
+                }
+
+                const isWrite = isWriteAccess(node);
+                let funType: Type | undefined;
+                if (isProp) {
+                    // since `__get__`/`__set__` cannot be found for properties, try to find the first
+                    // `fget`/`fset` information and use its method type if it exists
+                    funType = declarations
+                        .map((decl) => this._getPropertyInfo(decl, isWrite))
+                        .find((i) => i)?.methodType;
+                } else {
+                    // for non-properties, get the type of `__get__`/`__set__` of the descriptor instance
+                    const memberName = isWrite ? '__set__' : '__get__';
+                    const method = isWrite ? 'set' : 'get';
+                    const member = isClass(declaredType)
+                        ? this._evaluator.getTypeOfBoundMember(node, declaredType, memberName, { method: method })
+                        : undefined;
+                    funType = member?.type;
+                }
+                let effType: Type | undefined = undefined;
+                if (isWrite) {
+                    // for the setter, get the second argument (not counting `self`), which is the new value,
+                    // and use its type
+                    if (funType && isFunction(funType) && funType.shared.parameters.length >= 2) {
+                        effType = FunctionType.getParamType(funType, 1);
+                    }
+                } else {
+                    // for the getter, use the return type
+                    if (funType && isFunction(funType)) effType = FunctionType.getEffectiveReturnType(funType);
+                }
+
+                if (effType && isFunction(effType)) {
+                    const isMethod = effType.shared.declaration?.isMethod;
+                    return isMethod ? SemanticTokenTypes.method : SemanticTokenTypes.function;
+                }
+                if (effType && isOverloaded(effType)) {
+                    // check whether any overload has a method declaration
+                    const isMethod = OverloadedType.getOverloads(effType).some(
+                        (fType) => fType.shared.declaration?.isMethod
+                    );
+                    return isMethod ? SemanticTokenTypes.method : SemanticTokenTypes.function;
+                }
+                if (effType && TypeBase.isInstantiable(effType)) {
+                    // resolve type variables to their bound types
+                    if (isTypeVar(effType)) effType = effType.shared.boundType ?? effType;
+                    return isClass(effType) ? SemanticTokenTypes.class : SemanticTokenTypes.type;
+                }
+                return SemanticTokenTypes.property;
             }
         }
 

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/descriptors.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/descriptors.py
@@ -1,0 +1,60 @@
+from typing import Callable, Concatenate
+
+
+class DecFun[T, **P, R]:
+    def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+        self.fn = fn
+
+    def __get__(self, instance: T, owner: type[T]) -> Callable[P, R]:
+        def fun(*args: P.args, **kwargs: P.kwargs) -> R:
+            return self.fn(instance, *args, **kwargs)
+
+        return fun
+
+
+class DecType[T, **P, R]:
+    def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+        self.fn = fn
+
+    def __get__(self, instance: T, owner: type[T]) -> type[T]:
+        return owner
+
+
+class DecSet[T, **P, R]:
+    def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+        self.fn = fn
+
+    def __get__(self, instance: T, owner: type[T]):
+        return self.__get__
+
+    def __set__(self, instance: T, value: int):
+        pass
+
+
+class Bar:
+    @DecFun
+    def desc0(self): ...
+
+    @property
+    def desc1(self) -> int:
+        return 1
+
+    @desc1.setter
+    def desc1(self, value: Callable[[], int]):
+        _ = value()
+
+    @DecType
+    def desc2(self): ...
+
+    @DecSet
+    def desc3(self): ...
+
+
+bar = Bar()
+a = bar.desc0
+a()
+b = bar.desc1
+bar.desc1 = lambda: 1
+c = bar.desc2
+d = bar.desc3
+bar.desc3 = 1

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -122,6 +122,191 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         ]);
     });
 
+    test('descriptors', () => {
+        const result = semanticTokenizeSampleFile('descriptors.py');
+        expect(result).toStrictEqual([
+            [
+                // from typing import Callable, Concatenate
+                { type: 'namespace', modifiers: [], start: 5, length: 6 },
+                { type: 'class', modifiers: [], start: 19, length: 8 },
+                { type: 'class', modifiers: [], start: 29, length: 11 },
+                // class DecFun[T, **P, R]:
+                { type: 'class', modifiers: ['declaration'], start: 49, length: 6 },
+                { type: 'typeParameter', modifiers: [], start: 56, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 61, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 64, length: 1 },
+                // def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 76, length: 8 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 85, length: 4 },
+                { type: 'function', modifiers: ['declaration', 'parameter'], start: 91, length: 2 },
+                { type: 'class', modifiers: [], start: 95, length: 8 },
+                { type: 'class', modifiers: [], start: 104, length: 11 },
+                { type: 'typeParameter', modifiers: [], start: 116, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 119, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 123, length: 1 },
+                // self.fn = fn
+                { type: 'selfParameter', modifiers: ['parameter'], start: 144, length: 4 },
+                { type: 'function', modifiers: ['classMember'], start: 149, length: 2 },
+                { type: 'function', modifiers: ['parameter'], start: 154, length: 2 },
+                // def __get__(self, instance: T, owner: type[T]) -> Callable[P, R]:
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 166, length: 7 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 174, length: 4 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 180, length: 8 },
+                { type: 'typeParameter', modifiers: [], start: 190, length: 1 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 193, length: 5 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 200, length: 4 },
+                { type: 'typeParameter', modifiers: [], start: 205, length: 1 },
+                { type: 'class', modifiers: [], start: 212, length: 8 },
+                { type: 'typeParameter', modifiers: [], start: 221, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 224, length: 1 },
+                // def fun(*args: P.args, **kwargs: P.kwargs) -> R:
+                { type: 'function', modifiers: ['declaration'], start: 240, length: 3 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 245, length: 4 },
+                { type: 'typeParameter', modifiers: [], start: 251, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 253, length: 4 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 261, length: 6 },
+                { type: 'typeParameter', modifiers: [], start: 269, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 271, length: 6 },
+                { type: 'typeParameter', modifiers: [], start: 282, length: 1 },
+                // return self.fn(instance, *args, **kwargs)
+                { type: 'selfParameter', modifiers: ['parameter'], start: 304, length: 4 },
+                { type: 'function', modifiers: ['classMember'], start: 309, length: 2 },
+                { type: 'parameter', modifiers: ['parameter'], start: 312, length: 8 },
+                { type: 'parameter', modifiers: ['parameter'], start: 323, length: 4 },
+                { type: 'parameter', modifiers: ['parameter'], start: 331, length: 6 },
+                // return fun
+                { type: 'function', modifiers: [], start: 355, length: 3 },
+                // class DecType[T, **P, R]:
+                { type: 'class', modifiers: ['declaration'], start: 367, length: 7 },
+                { type: 'typeParameter', modifiers: [], start: 375, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 380, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 383, length: 1 },
+                // def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 395, length: 8 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 404, length: 4 },
+                { type: 'function', modifiers: ['declaration', 'parameter'], start: 410, length: 2 },
+                { type: 'class', modifiers: [], start: 414, length: 8 },
+                { type: 'class', modifiers: [], start: 423, length: 11 },
+                { type: 'typeParameter', modifiers: [], start: 435, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 438, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 442, length: 1 },
+                // self.fn = fn
+                { type: 'selfParameter', modifiers: ['parameter'], start: 463, length: 4 },
+                { type: 'function', modifiers: ['classMember'], start: 468, length: 2 },
+                { type: 'function', modifiers: ['parameter'], start: 473, length: 2 },
+                // def __get__(self, instance: T, owner: type[T]) -> type[T]:
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 485, length: 7 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 493, length: 4 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 499, length: 8 },
+                { type: 'typeParameter', modifiers: [], start: 509, length: 1 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 512, length: 5 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 519, length: 4 },
+                { type: 'typeParameter', modifiers: [], start: 524, length: 1 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 531, length: 4 },
+                { type: 'typeParameter', modifiers: [], start: 536, length: 1 },
+                // return owner
+                { type: 'parameter', modifiers: ['parameter'], start: 555, length: 5 },
+                // class DecSet[T, **P, R]:
+                { type: 'class', modifiers: ['declaration'], start: 569, length: 6 },
+                { type: 'typeParameter', modifiers: [], start: 576, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 581, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 584, length: 1 },
+                // def __init__(self, fn: Callable[Concatenate[T, P], R]) -> None:
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 596, length: 8 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 605, length: 4 },
+                { type: 'function', modifiers: ['declaration', 'parameter'], start: 611, length: 2 },
+                { type: 'class', modifiers: [], start: 615, length: 8 },
+                { type: 'class', modifiers: [], start: 624, length: 11 },
+                { type: 'typeParameter', modifiers: [], start: 636, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 639, length: 1 },
+                { type: 'typeParameter', modifiers: [], start: 643, length: 1 },
+                // self.fn = fn
+                { type: 'selfParameter', modifiers: ['parameter'], start: 664, length: 4 },
+                { type: 'function', modifiers: ['classMember'], start: 669, length: 2 },
+                { type: 'function', modifiers: ['parameter'], start: 674, length: 2 },
+                // def __get__(self, instance: T, owner: type[T]):
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 686, length: 7 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 694, length: 4 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 700, length: 8 },
+                { type: 'typeParameter', modifiers: [], start: 710, length: 1 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 713, length: 5 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 720, length: 4 },
+                { type: 'typeParameter', modifiers: [], start: 725, length: 1 },
+                // return self.__get__
+                { type: 'selfParameter', modifiers: ['parameter'], start: 745, length: 4 },
+                { type: 'method', modifiers: ['classMember'], start: 750, length: 7 },
+                // def __set__(self, instance: T, value: int):
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 767, length: 7 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 775, length: 4 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 781, length: 8 },
+                { type: 'typeParameter', modifiers: [], start: 791, length: 1 },
+                { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 794, length: 5 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 801, length: 3 },
+                // class Bar:
+                { type: 'class', modifiers: ['declaration'], start: 828, length: 3 },
+                // @DecFun def desc0(self): ...
+                { type: 'function', modifiers: ['declaration', 'classMember', 'readonly'], start: 853, length: 5 },
+                { type: 'decorator', modifiers: [], start: 837, length: 1 },
+                { type: 'decorator', modifiers: [], start: 838, length: 6 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 859, length: 4 },
+                // @property def desc1(self) -> int: return 1
+                { type: 'property', modifiers: ['declaration', 'classMember'], start: 893, length: 5 },
+                { type: 'decorator', modifiers: [], start: 875, length: 1 },
+                { type: 'decorator', modifiers: [], start: 876, length: 8 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 899, length: 4 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 908, length: 3 },
+                // @desc1.setter def desc1(self, value: Callable[[], int]): _ = value()
+                { type: 'property', modifiers: ['declaration', 'classMember'], start: 957, length: 5 },
+                { type: 'decorator', modifiers: [], start: 935, length: 1 },
+                { type: 'property', modifiers: ['classMember'], start: 936, length: 5 },
+                { type: 'method', modifiers: ['classMember'], start: 942, length: 6 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 963, length: 4 },
+                { type: 'function', modifiers: ['declaration', 'parameter'], start: 969, length: 5 },
+                { type: 'class', modifiers: [], start: 976, length: 8 },
+                { type: 'class', modifiers: ['defaultLibrary', 'builtin'], start: 989, length: 3 },
+                { type: 'variable', modifiers: [], start: 1004, length: 1 },
+                { type: 'function', modifiers: ['parameter'], start: 1008, length: 5 },
+                // @DecType def desc2(self): ...
+                { type: 'class', modifiers: ['declaration', 'classMember', 'readonly'], start: 1038, length: 5 },
+                { type: 'decorator', modifiers: [], start: 1021, length: 1 },
+                { type: 'decorator', modifiers: [], start: 1022, length: 7 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 1044, length: 4 },
+                // @DecSet def desc3(self): ...
+                { type: 'method', modifiers: ['declaration', 'classMember'], start: 1076, length: 5 },
+                { type: 'decorator', modifiers: [], start: 1060, length: 1 },
+                { type: 'decorator', modifiers: [], start: 1061, length: 6 },
+                { type: 'selfParameter', modifiers: ['declaration', 'parameter'], start: 1082, length: 4 },
+                // bar = Bar()
+                { type: 'variable', modifiers: [], start: 1095, length: 3 },
+                { type: 'class', modifiers: [], start: 1101, length: 3 },
+                // a = bar.desc0
+                { type: 'function', modifiers: [], start: 1107, length: 1 },
+                { type: 'variable', modifiers: [], start: 1111, length: 3 },
+                { type: 'function', modifiers: ['classMember', 'readonly'], start: 1115, length: 5 },
+                // a()
+                { type: 'function', modifiers: [], start: 1121, length: 1 },
+                // b = bar.desc1
+                { type: 'variable', modifiers: [], start: 1125, length: 1 },
+                { type: 'variable', modifiers: [], start: 1129, length: 3 },
+                { type: 'property', modifiers: ['classMember'], start: 1133, length: 5 },
+                // bar.desc1 = lambda: 1
+                { type: 'variable', modifiers: [], start: 1139, length: 3 },
+                { type: 'function', modifiers: ['classMember'], start: 1143, length: 5 },
+                // c = bar.desc2
+                { type: 'class', modifiers: [], start: 1161, length: 1 },
+                { type: 'variable', modifiers: [], start: 1165, length: 3 },
+                { type: 'class', modifiers: ['classMember', 'readonly'], start: 1169, length: 5 },
+                // d = bar.desc3
+                { type: 'function', modifiers: [], start: 1175, length: 1 },
+                { type: 'variable', modifiers: [], start: 1179, length: 3 },
+                { type: 'method', modifiers: ['classMember'], start: 1183, length: 5 },
+                // bar.desc3 = 1
+                { type: 'variable', modifiers: [], start: 1189, length: 3 },
+                { type: 'property', modifiers: ['classMember'], start: 1193, length: 5 },
+            ],
+        ]);
+    });
+
     test('enum', () => {
         const result = semanticTokenizeSampleFile('enum.py');
         expect(result).toStrictEqual([


### PR DESCRIPTION
This PR addresses #1538 by highlighting properties and other descriptor instances based on the type of the value represented by the descriptor.

For this, properties need to be handled separately, as querying the `__get__`/`__set__` method of the descriptor instance does not work for properties; instead, information about `fget`/`fset` needs to queried for properties. This PR also distinguishes between assignments, for which the type of the second argument of the setter (when ignoring the `self` parameter) is used, and other uses of a descriptor instance, for which the return type of the getter is used. The implementation handles methods/functions and classes/types and includes a test for this new behaviour.

The behaviour of the test looks reasonable to me, but if I have overlooked something important (especially something not included in this test), I’m happy to go on refining the implementation.