### PR TITLE
use the name `basedpyright` instead of `python` when instantiating vscode's `LanguageClient` so that the logging can be configured using `basedpyright.trace.server`

### DIFF
--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -268,7 +268,7 @@ export async function activate(context: ExtensionContext) {
     };
 
     // Create the language client and start the client.
-    const client = new LanguageClient('python', toolName, serverOptions, clientOptions);
+    const client = new LanguageClient('basedpyright', toolName, serverOptions, clientOptions);
     languageClient = client;
 
     // Register our custom commands.


### PR DESCRIPTION
fixes #1578