### PR TITLE
fix an accidental breaking change to `dataclass_transform` that was introduced in pyright 1.1.407

### DIFF
--- a/packages/pyright-internal/src/analyzer/decorators.ts
+++ b/packages/pyright-internal/src/analyzer/decorators.ts
@@ -325,7 +325,7 @@ export function applyClassDecorator(
         }
     }
 
-    const applyDataclassTransform = (): void => {
+    const applyDataclassTransform = (): boolean => {
         // Is this a dataclass decorator?
         let dataclassBehaviors: DataClassBehaviors | undefined;
         let callNode: CallNode | undefined;
@@ -344,7 +344,9 @@ export function applyClassDecorator(
 
         if (dataclassBehaviors) {
             applyDataClassDecorator(evaluator, decoratorNode, originalClassType, dataclassBehaviors, callNode);
+            return true;
         }
+        return false;
     };
 
     if (isOverloaded(decoratorType)) {
@@ -383,14 +385,18 @@ export function applyClassDecorator(
             return inputClassType;
         }
 
-        applyDataclassTransform();
+        if (applyDataclassTransform()) {
+            return inputClassType;
+        }
     } else if (isClassInstance(decoratorType)) {
         if (ClassType.isBuiltIn(decoratorType, 'deprecated')) {
             originalClassType.shared.deprecatedMessage = decoratorType.priv.deprecatedInstanceMessage;
             return inputClassType;
         }
 
-        applyDataclassTransform();
+        if (applyDataclassTransform()) {
+            return inputClassType;
+        }
     }
 
     return getTypeOfDecorator(evaluator, decoratorNode, inputClassType);

--- a/packages/pyright-internal/src/tests/samples/based_dataclass_transform_changes_return_type.py
+++ b/packages/pyright-internal/src/tests/samples/based_dataclass_transform_changes_return_type.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import assert_type, dataclass_transform
+
+
+@dataclass_transform()
+def foo(cls: type[object]) -> object:
+    return dataclass(cls)
+
+
+@foo
+class Foo:
+    a: int
+
+
+_ = assert_type(Foo, type[Foo])
+asdf = Foo(a=1)

--- a/packages/pyright-internal/src/tests/samples/dataclass_transform_callable_protocol.py
+++ b/packages/pyright-internal/src/tests/samples/dataclass_transform_callable_protocol.py
@@ -1,0 +1,33 @@
+from collections.abc import Callable
+from typing import Protocol, assert_type, dataclass_transform
+from dataclasses import dataclass
+
+
+@dataclass_transform(kw_only_default=True)
+def rescoped[T: type](*, frozen: bool = False) -> Callable[[T], T]:
+    return dataclass(frozen=frozen)  # pyright: ignore[reportUnknownVariableType]
+
+@rescoped()
+class Foo:
+    x: str
+    y: int
+
+FOO = Foo(x="a", y=42)  # works
+
+
+class Decorator(Protocol):
+    def __call__[T: type](self, t: T, /) -> T:
+        ...
+
+@dataclass_transform(kw_only_default=True)
+def spec(*, frozen: bool = False) -> Decorator:
+    return dataclass(frozen=frozen)  # pyright: ignore[reportUnknownVariableType]
+
+@spec()
+class Bar:
+    x: str
+    y: int
+
+BAR = Bar(x="a", y=42)
+
+_ = assert_type(BAR, Bar)

--- a/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
+++ b/packages/pyright-internal/src/tests/typeEvaluatorBased.test.ts
@@ -221,45 +221,69 @@ test('`reportInvalidTypeVarUse`', () => {
     });
 });
 
-test('dataclass_transform skip_replace', () => {
-    const configOptions = new ConfigOptions(Uri.empty());
-    configOptions.diagnosticRuleSet.enableBasedFeatures = true;
-    const analysisResults = typeAnalyzeSampleFiles(['based_dataclass_skip_replace/sample.py'], configOptions);
-    validateResultsButBased(analysisResults, {
-        errors: [
-            {
-                code: DiagnosticRule.reportCallIssue,
-                line: 28,
-                message: 'No parameter named "z"',
-            },
-            {
-                code: DiagnosticRule.reportAttributeAccessIssue,
-                line: 39,
-                message:
-                    'Cannot access attribute "__replace__" for class "B"\n' + '  Attribute "__replace__" is unknown',
-            },
-            {
-                code: DiagnosticRule.reportAttributeAccessIssue,
-                line: 50,
-                message:
-                    'Cannot access attribute "__replace__" for class "C"\n' + '  Attribute "__replace__" is unknown',
-            },
-            {
-                code: DiagnosticRule.reportAttributeAccessIssue,
-                line: 62,
-                message:
-                    'Cannot access attribute "__replace__" for class "D"\n' + '  Attribute "__replace__" is unknown',
-            },
-            {
-                code: DiagnosticRule.reportAssignmentType,
-                line: 74,
-                message:
-                    'Type "Box[int]" is not assignable to declared type "Box[bool]"\n' +
-                    '  "Box[int]" is not assignable to "Box[bool]"\n' +
-                    '    Type parameter "T@Box" is covariant, but "int" is not a subtype of "bool"\n' +
-                    '      "int" is not assignable to "bool"',
-            },
-        ],
+describe('dataclass_transform', () => {
+    test('skip_replace', () => {
+        const configOptions = new ConfigOptions(Uri.empty());
+        configOptions.diagnosticRuleSet.enableBasedFeatures = true;
+        const analysisResults = typeAnalyzeSampleFiles(['based_dataclass_skip_replace/sample.py'], configOptions);
+        validateResultsButBased(analysisResults, {
+            errors: [
+                {
+                    code: DiagnosticRule.reportCallIssue,
+                    line: 28,
+                    message: 'No parameter named "z"',
+                },
+                {
+                    code: DiagnosticRule.reportAttributeAccessIssue,
+                    line: 39,
+                    message:
+                        'Cannot access attribute "__replace__" for class "B"\n' +
+                        '  Attribute "__replace__" is unknown',
+                },
+                {
+                    code: DiagnosticRule.reportAttributeAccessIssue,
+                    line: 50,
+                    message:
+                        'Cannot access attribute "__replace__" for class "C"\n' +
+                        '  Attribute "__replace__" is unknown',
+                },
+                {
+                    code: DiagnosticRule.reportAttributeAccessIssue,
+                    line: 62,
+                    message:
+                        'Cannot access attribute "__replace__" for class "D"\n' +
+                        '  Attribute "__replace__" is unknown',
+                },
+                {
+                    code: DiagnosticRule.reportAssignmentType,
+                    line: 74,
+                    message:
+                        'Type "Box[int]" is not assignable to declared type "Box[bool]"\n' +
+                        '  "Box[int]" is not assignable to "Box[bool]"\n' +
+                        '    Type parameter "T@Box" is covariant, but "int" is not a subtype of "bool"\n' +
+                        '      "int" is not assignable to "bool"',
+                },
+            ],
+        });
+    });
+    test('returns a callable protocol', () => {
+        // test for an issue that was fixed upstream but didn't have a test. see https://github.com/microsoft/pyright/issues/11015
+        const configOptions = new ConfigOptions(Uri.empty());
+        const analysisResults = typeAnalyzeSampleFiles(['dataclass_transform_callable_protocol.py'], configOptions);
+        validateResultsButBased(analysisResults, {});
+    });
+    test('changes return type to something else', () => {
+        // when the function decorated with `@dataclass_transform` is annotated as returning a different type, we want to ignore it
+        // because `dataclass_transform`'s purpose is to transform the decorated class into a dataclass, not some other type.
+        // ideally this should be an error, but pydantic (and presumably other libraries that use dataclass_transform) depend on
+        // the behavior prior to pyright 1.1.407, which fixed the scenario in the 'returns a callable protocol' test but broke this one.
+        // in basedpyright we modify the logic to fix the original issue without introducing a breaking change.
+        const configOptions = new ConfigOptions(Uri.empty());
+        const analysisResults = typeAnalyzeSampleFiles(
+            ['based_dataclass_transform_changes_return_type.py'],
+            configOptions
+        );
+        validateResultsButBased(analysisResults, {});
     });
 });
 


### PR DESCRIPTION
fixes #1594