### PR TITLE
Add neovim LSP server setting example using 0.11 format

### DIFF
--- a/docs/configuration/language-server-settings.md
+++ b/docs/configuration/language-server-settings.md
@@ -114,6 +114,25 @@ the basedpyright language server settings can be configured using a workspace or
 
 The language server can be configured in your neovim settings:
 
+For Neovim 0.11+
+
+```lua title="lsp/basedpyright.lua"
+return {
+  settings = {
+    basedpyright = {
+      analysis = {
+        diagnosticMode = "openFilesOnly",
+        inlayHints = {
+          callArgumentNames = true
+        }
+      }
+    }
+  }
+}
+```
+
+For Neovim 0.10 (legacy)
+
 ```lua
 require("lspconfig").basedpyright.setup {
   settings = {


### PR DESCRIPTION
Fixes #1406

This PR addresses #1406 by adding an example of how we can configure basedpyright using neovim 0.11's native LSP configuration option.