### PR TITLE
Fix semantic token of variable of `TypeVar` type

### DIFF
--- a/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
+++ b/packages/pyright-internal/src/analyzer/semanticTokensWalker.ts
@@ -426,10 +426,10 @@ export class SemanticTokensWalker extends ParseTreeWalker {
             !isParam && this._applyClassMemberAccessModifiers(node, declarations, modifiers, readOnly);
 
         if (!isParam) {
-            // Handle variables that have been assigned a “TypeVar”
+            // Handle variables that have been assigned a `TypeVar` (not those whose type is a `TypeVar`)
             // There are weird cases in which bogus type variables are synthesized
-            // Example: Left-hand side “x” of “self.x = x” in “parameters.py”
-            if (isTypeVar(type) && !type.shared.isSynthesized) {
+            // Example: Left-hand side `x` of `self.x = x` in `parameters.py`
+            if (isTypeVar(type) && !type.shared.isSynthesized && TypeBase.isInstantiable(type)) {
                 return SemanticTokenTypes.typeParameter;
             }
         }

--- a/packages/pyright-internal/src/tests/samples/semantic_highlighting/type_var.py
+++ b/packages/pyright-internal/src/tests/samples/semantic_highlighting/type_var.py
@@ -1,0 +1,13 @@
+from typing import TypeVar
+
+
+def foo[T](value: T):
+    _bar: T = value
+
+
+_T = TypeVar("_T")
+
+
+def fooo(value: _T) -> _T:
+    _bar: _T = value
+    return _bar

--- a/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
+++ b/packages/pyright-internal/src/tests/semanticTokensProvider.test.ts
@@ -330,6 +330,31 @@ if (process.platform !== 'win32' || !process.env['CI']) {
         ]);
     });
 
+    test('type variables', () => {
+        const result = semanticTokenizeSampleFile('type_var.py');
+        expect(result).toStrictEqual([
+            { type: 'namespace', modifiers: [], start: 5, length: 6 }, // typing
+            { type: 'class', modifiers: [], start: 19, length: 7 }, // TypeVar
+            { type: 'function', modifiers: ['declaration'], start: 33, length: 3 }, // foo
+            { type: 'typeParameter', modifiers: [], start: 37, length: 1 }, // T
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 40, length: 5 }, // value
+            { type: 'typeParameter', modifiers: [], start: 47, length: 1 }, // T
+            { type: 'variable', modifiers: [], start: 55, length: 4 }, // _bar
+            { type: 'typeParameter', modifiers: [], start: 61, length: 1 }, // T
+            { type: 'parameter', modifiers: ['parameter'], start: 65, length: 5 }, // value
+            { type: 'typeParameter', modifiers: ['readonly'], start: 73, length: 2 }, // _T
+            { type: 'class', modifiers: [], start: 78, length: 7 }, // TypeVar
+            { type: 'function', modifiers: ['declaration'], start: 98, length: 4 }, // fooo
+            { type: 'parameter', modifiers: ['declaration', 'parameter'], start: 103, length: 5 }, // value
+            { type: 'typeParameter', modifiers: ['readonly'], start: 110, length: 2 }, // _T
+            { type: 'typeParameter', modifiers: ['readonly'], start: 117, length: 2 }, // _T
+            { type: 'variable', modifiers: [], start: 125, length: 4 }, // _bar
+            { type: 'typeParameter', modifiers: ['readonly'], start: 131, length: 2 }, // _T
+            { type: 'parameter', modifiers: ['parameter'], start: 136, length: 5 }, // value
+            { type: 'variable', modifiers: [], start: 153, length: 4 }, // _bar
+        ]);
+    });
+
     test('imports', () => {
         const result = semanticTokenizeSampleFile('imports.py');
         expect(result).toStrictEqual([


### PR DESCRIPTION
This PR addresses #1585 by only highlighting variables whose type is an _instantiable_ type variable as `typeParameter`.