### PR TITLE
typeshed `float | int`

### DIFF
--- a/build/py3_8/float_int_stubs.py
+++ b/build/py3_8/float_int_stubs.py
@@ -192,14 +192,14 @@ class AnnotationTrackingVisitor(ast.NodeVisitor):
         super().generic_visit(node)
 
 
-def float_expand(stubs_with_docs_path: Path) -> None:
+def float_expand(stubs: Path) -> None:
     """change stubs in the given directory from `float` to `float | int`"""
-    for dir_path, _dir_names, file_names in os.walk(stubs_with_docs_path):
+    for dir_path, _dir_names, file_names in os.walk(stubs):
         for file_name in file_names:
             if not file_name.endswith(".pyi"):
                 continue
             file_path = Path(dir_path) / file_name
-            rel_path = Path(os.path.relpath(file_path, stubs_with_docs_path)).as_posix()
+            rel_path = Path(os.path.relpath(file_path, stubs)).as_posix()
             file_bytes = Path(file_path).read_bytes()
             file_parsed = ast.parse(file_bytes)
             v = AnnotationTrackingVisitor(rel_path)


### PR DESCRIPTION
to make https://github.com/DetachHead/basedpyright/issues/319 easier

modifies typeshed stubs, changing `float` to `float | int`

- doesn't change `Final[float]`
- doesn't change return type ` -> float`
  - We might find with experiments that we want to change some return types, but then we'd want a big list of exceptions.

~~I thought it might be good to put it in a different file, but~~ it looks like this `generate_docstubs.py` is made to be used as both an importable module and an entry point, making a relative import with no package problematic.