### PR TITLE
Skip mypy_primer on pure localization updates

### DIFF
--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -21,6 +21,9 @@ on:
     paths:
       - 'packages/pyright/**'
       - 'packages/pyright-internal/src/**'
+      - '!packages/pyright-internal/src/localization/**' # first exclude localization data
+      - 'packages/pyright-internal/src/localization/*.ts' # then re-include *.ts
+      - 'packages/pyright-internal/src/localization/package.nls.en-us.json' # re-include en-us data
       - 'packages/pyright-internal/typeshed-fallback/**'
       - '.github/workflows/mypy_primer_*.yaml'
 

--- a/.github/workflows/mypy_primer_push.yaml
+++ b/.github/workflows/mypy_primer_push.yaml
@@ -12,6 +12,9 @@ on:
     paths:
       - 'packages/pyright/**'
       - 'packages/pyright-internal/src/**'
+      - '!packages/pyright-internal/src/localization/**' # first exclude localization data
+      - 'packages/pyright-internal/src/localization/*.ts' # then re-include *.ts
+      - 'packages/pyright-internal/src/localization/package.nls.en-us.json' # re-include en-us data
       - 'packages/pyright-internal/typeshed-fallback/**'
       - '.github/workflows/mypy_primer_*.yaml'
   # Also run manually if requested.


### PR DESCRIPTION
The [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore) says:

> The order that you define paths patterns matters:
> - A matching negative pattern (prefixed with !) after a positive match will exclude the path.
> - A matching positive pattern after a negative match will include the path again.

resolve #890 