### PR TITLE
add config to separate builtins

### DIFF
--- a/packages/pyright-internal/src/tests/argumentsMatchParamNames.test.ts
+++ b/packages/pyright-internal/src/tests/argumentsMatchParamNames.test.ts
@@ -16,6 +16,18 @@ test('it reports an error', () => {
                 line: 11,
                 code: DiagnosticRule.reportPositionalArgumentNameMismatch,
             },
+            {
+                line: 25,
+                code: DiagnosticRule.reportPositionalArgumentNameMismatch,
+            },
+            {
+                line: 32,
+                code: DiagnosticRule.reportPositionalArgumentNameMismatch,
+            },
+            {
+                line: 33,
+                code: DiagnosticRule.reportPositionalArgumentNameMismatch,
+            },
         ],
     });
 });

--- a/packages/pyright-internal/src/tests/samples/argumentsMatchParamNames.py
+++ b/packages/pyright-internal/src/tests/samples/argumentsMatchParamNames.py
@@ -21,3 +21,15 @@ foo(
     height,  # okay, matches
     width=length,  # okay, using keyword
 )
+
+foo(
+    1, # should display a warning, positional argument used
+    width=2, # okay, using keyword
+)
+
+len([]) # okay, built-in function with no keyword arguments
+
+pow(
+    2, # should display a warning, positional argument used, built-in function
+    3, # should display a warning, positional argument used, built-in function
+)


### PR DESCRIPTION
Without this additional configuration, the rule is too noisy on generally standard behaviour