### PR TITLE
fix crash in the playground

### DIFF
--- a/packages/browser-pyright/webpack.config.js
+++ b/packages/browser-pyright/webpack.config.js
@@ -76,6 +76,7 @@ module.exports = async (_, { mode }) => {
         plugins: [
             new DefinePlugin({
                 // Just enough to avoid the memory check that pyright performs in pyright-internal/src/analyzer/program.ts
+                // also used by the the is-ci package
                 process: { env: {}, execArgv: [], cwd: () => '/', memoryUsage: () => ({ heapUsed: 0, rss: 1 }) },
             }),
             new ProvidePlugin({


### PR DESCRIPTION
no idea wtf is going on here, but if this `DefinePlugin` thing is defined as a string, it only replaces *some* usages of process but not others?

```ts
const foo = process.env // doesn't get replaced
console.log(process.env["asdf"]) // does get replaced
```
we really need to ditch webpack ASAP

fixes https://github.com/DetachHead/basedpyright-playground/issues/45