### PR TITLE
Fix out of bounds top-level `activeParameter` being set when an individual signature has an `activeParameter`

### DIFF
--- a/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
+++ b/packages/pyright-internal/src/languageService/signatureHelpProvider.ts
@@ -215,11 +215,13 @@ export class SignatureHelpProvider {
             // We could apply this hack to each individual signature such that they all specify
             // activeParameter, but that would make it more difficult to determine which actually
             // are active when comparing, and we already have to set this for clients which don't
-            // support per-signature activeParameter.
+            // support per-signature activeParameter (although the top-level activeParameter is
+            // deprecated as of LSP version 3.16 so we will eventually need to do that anyway).
             //
             // See:
             //   - https://github.com/microsoft/language-server-protocol/issues/1271
             //   - https://github.com/microsoft/pyright/pull/1783
+            //   - https://github.com/microsoft/language-server-protocol/issues/2080
             activeParameter = Math.max(...signatures.map((s) => s.parameters?.length ?? 0));
         }
 


### PR DESCRIPTION
fixes #972