### PR TITLE
fix `skip_replace` hack docs

### DIFF
--- a/docs/benefits-over-pyright/dataclass-transform.md
+++ b/docs/benefits-over-pyright/dataclass-transform.md
@@ -18,9 +18,9 @@ to allow type checkers to add their own little hacks on top of the standard ones
     Pyright (and basedpyright) assumes that classes produced by a dataclass transform
     define a `__replace__` method, as long as the class is not marked with `init=False` and does
     not define a custom `__init__` method.
-    However, `typing.dataclass_transform` doesn't require that the `__replace__` method is defined.
+    You may want a `dataclass`-like decorator or metaclass that does not support `__replace__` at all.
 
-    In addition, `__replace__` messes with the variance inference of frozen dataclasses (see
+    In particular, `__replace__` messes with the variance inference of frozen dataclasses (see
     [this discourse thread](https://discuss.python.org/t/make-replace-stop-interfering-with-variance-inference/96092)
     for details). Here's a recipe you can use to work around this:
 


### PR DESCRIPTION
I was recently pointed to the fact that the typing documentation does in fact demand that `dataclass_transform`s support `__replace__`:

https://typing.python.org/en/latest/spec/dataclasses.html#the-dataclass-transform-decorator

> Except where stated otherwise, classes impacted by dataclass_transform, either by inheriting from a class that is decorated with dataclass_transform or by being decorated with a function decorated with dataclass_transform, are assumed to behave like stdlib [dataclass()](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass).

So the documentation I wrote was wrong: type checkers are supposed to assume that the `dataclass_transform` produces classes with `__replace__` support in 3.13+.