### PR TITLE
fix $schema being reported as unrecognized setting in config files

### DIFF
--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -1577,11 +1577,13 @@ export class ConfigOptions {
         this.initializedFromJson = true;
         const console = serviceProvider.tryGet(ServiceKeys.console) ?? new NullConsole();
 
-        // we initialize it with `extends` because this option gets read before this function gets called
-        // 'executionEnvironments' also gets read elsewhere
         const unusedConfigDetector = new UnusedConfigDetector<Record<string, object>>(configObj, [
+            // We ignore these because they get read elsewhere:
             'extends',
             'executionEnvironments',
+            // VS Code supports setting "$schema" in a JSON file to pick a validation schema.
+            // See https://code.visualstudio.com/docs/languages/json#_mapping-in-the-json
+            '$schema',
         ]);
         configObj = unusedConfigDetector.proxy;
 

--- a/packages/pyright-internal/src/tests/config.test.ts
+++ b/packages/pyright-internal/src/tests/config.test.ts
@@ -218,6 +218,26 @@ describe(`config test'}`, () => {
         assert.equal(configOptions.executionEnvironments[0].pythonPlatform, 'Linux');
     });
 
+    test('$schema is recognized', () => {
+        const cwd = UriEx.file(normalizePath(process.cwd()));
+
+        const configOptions = new ConfigOptions(cwd);
+
+        const json = {
+            $schema:
+                'https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json',
+            typeCheckingMode: 'basic',
+        };
+
+        const fs = new TestFileSystem(/* ignoreCase */ false);
+        const console = new ErrorTrackingNullConsole();
+
+        const sp = createServiceProvider(fs, console);
+        configOptions.initializeFromJson(json, cwd, sp, new NoAccessHost());
+
+        assert.deepStrictEqual(console.errors, []);
+    });
+
     describe('invalid config', () => {
         test('unknown top-level option', () => {
             const cwd = UriEx.file(normalizePath(process.cwd()));


### PR DESCRIPTION
## Summary
- Added `$schema` to the list of recognized config options
- Prevents spurious error when using JSON schema validation in config files
- Fixes #1651