### PR TITLE
show the default value from the implementation signature when displaying an overload signature (eg. hover and signature help) if its default value is an ellipsis

### DIFF
--- a/packages/pyright-internal/src/tests/fourslash/signature.overloadDefaultValues.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/signature.overloadDefaultValues.fourslash.ts
@@ -1,0 +1,31 @@
+/// <reference path="typings/fourslash.d.ts" />
+
+// @filename: foo.py
+//// from typing import overload
+////
+//// @overload
+//// def foo(value: int = ...) -> int: ...
+////
+//// @overload
+//// def foo(value: str) -> str: ...
+////
+//// def foo(value: int | str = 0) -> int | str: ...
+//// foo([|/*s1*/|]
+
+{
+    helper.verifySignature('plaintext', {
+        s1: {
+            signatures: [
+                {
+                    label: '(value: int = 0) -> int',
+                    parameters: ['value: int = 0'],
+                },
+                {
+                    label: '(value: str) -> str',
+                    parameters: ['value: str'],
+                },
+            ],
+            activeParameters: [0, 0],
+        },
+    });
+}


### PR DESCRIPTION
this change is mainly just to showcase that this is easy for a language server to do

see https://github.com/astral-sh/ruff/issues/23064#issuecomment-3845144088

<img width="451" height="271" alt="image" src="https://github.com/user-attachments/assets/748c4dff-9c33-4b62-a362-b5b9f98efb24" />