### PR TITLE
fix typing_extensions auto-import

### DIFF
--- a/packages/pyright-internal/src/analyzer/importResolver.ts
+++ b/packages/pyright-internal/src/analyzer/importResolver.ts
@@ -1209,6 +1209,11 @@ export class ImportResolver {
                         execEnv.pythonPlatform
                     )
                 ) {
+                    // typeshed says that 'typing_extensions' is stdlib
+                    // so we fix that with this special case
+                    if (moduleName === 'typing_extensions') {
+                        importType = ImportType.ThirdParty;
+                    }
                     return {
                         moduleName,
                         importType,

--- a/packages/pyright-internal/src/tests/completions.test.ts
+++ b/packages/pyright-internal/src/tests/completions.test.ts
@@ -2343,6 +2343,50 @@ describe('useTypingExtensions', () => {
     });
 });
 
+test('typing_extensions auto-import should be placed in third-party section', async () => {
+    const code = `
+// @filename: pyrightconfig.json
+//// { "pythonVersion": "3.10" }
+
+// @filename: test.py
+//// from unittest import TestCase[|/*importMarker*/|]
+////
+//// [|override/*marker*/|]
+    `;
+
+    const state = parseAndGetTestState(code).state;
+
+    // If it's stdlib, it will be placed alphabetically before unittest (old bugged behavior)
+    await state.verifyCompletion(
+        'included',
+        'markdown',
+        {
+            ['marker']: {
+                completions: [
+                    {
+                        label: 'override',
+                        kind: CompletionItemKind.Function,
+                        detail: 'Auto-import',
+                        textEdit: {
+                            range: state.getPositionRange('marker'),
+                            newText: 'override',
+                        },
+                        additionalTextEdits: [
+                            {
+                                range: state.getPositionRange('importMarker'),
+                                newText: '\n\nfrom typing_extensions import override',
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        undefined,
+        undefined,
+        false
+    );
+});
+
 test('import from stdlib package', async () => {
     const code = `
 // @filename: test.py


### PR DESCRIPTION
typeshed treats `typing_extensions` as stdlib
So when the auto-import inserts it, it inserts it in the stdlib section.
This fixes it to put it in the 3rd party section.

before:
```py
from typing_extensions import override
from unittest import TestCase
```

after:
```py
from unittest import TestCase

from typing_extensions import override
```