### PR TITLE
Quality: Mutable internal state is exposed directly by logger

### DIFF
--- a/packages/pyright-internal/src/analyzer/importLogger.ts
+++ b/packages/pyright-internal/src/analyzer/importLogger.ts
@@ -15,6 +15,6 @@ export class ImportLogger {
     }
 
     getLogs() {
-        return this._logs;
+        return [...this._logs];
     }
 }


### PR DESCRIPTION
## Problem

`ImportLogger.getLogs()` returns the backing `_logs` array directly, allowing callers to mutate internal state (e.g. `push`, `splice`, clearing logs) and break encapsulation.

**Severity**: `medium`
**File**: `packages/pyright-internal/src/analyzer/importLogger.ts`

## Solution

Return a defensive copy (`return [...this._logs]`) or a readonly view (`ReadonlyArray<string>`) to prevent external mutation.

## Changes

- `packages/pyright-internal/src/analyzer/importLogger.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
