### PR TITLE
Quality: Entry-point scripts disable all TypeScript checking

### DIFF
--- a/packages/pyright/index.js
+++ b/packages/pyright/index.js
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-
 // Stash the base directory into a global variable.
 global.__rootDirectory = __dirname + '/dist/';
 


### PR DESCRIPTION
## Problem

The Node entrypoints use `// @ts-nocheck`, which suppresses all static checks in executable startup code. This can hide runtime-affecting mistakes in critical bootstrap paths.

**Severity**: `medium`
**File**: `packages/pyright/index.js`

## Solution

Remove `@ts-nocheck` and either migrate these files to typed `.ts` wrappers or keep them as `.js` with targeted ESLint/TS suppressions only where needed.

## Changes

- `packages/pyright/index.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
