### PR TITLE
fix error attempting to baseline diagnostics from the new `string.templatelib` module when targeting python 3.14

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,11 +36,15 @@
         {
             "name": "Pyright current file",
             "type": "node",
+            "runtimeExecutable": "${workspaceFolder}/.venv/bin/node",
             "request": "launch",
             "preLaunchTask": "npm: build:cli:dev",
             "console": "integratedTerminal",
             "program": "${workspaceFolder}/packages/pyright/index.js",
-            "args": ["${file}"]
+            "args": ["${file}"],
+            "windows": {
+                "runtimeExecutable": "${workspaceFolder}/.venv/Scripts/node.exe"
+            }
         },
         {
             "name": "Pyright CLI (pyright-internal)",

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -1015,7 +1015,13 @@ export class Program {
         const fileDiagnostics: FileDiagnostics[] = this._removeUnneededFiles();
 
         this._sourceFileList.forEach((sourceFileInfo) => {
-            if (this._shouldCheckFile(sourceFileInfo)) {
+            if (
+                this._shouldCheckFile(sourceFileInfo) &&
+                // we never want to show diagnostics in non-user files. ideally we would check this as part of
+                // `_shouldCheckFile` but there are other places where that function is used that seem to require
+                // non-user files to be checked otherwise they won't show up in completions
+                isUserCode(sourceFileInfo)
+            ) {
                 let diagnostics = sourceFileInfo.sourceFile.getDiagnostics(
                     options,
                     reportDeltasOnly ? sourceFileInfo.diagnosticsVersion : undefined

--- a/packages/pyright-internal/src/tests/sourceFile.test.ts
+++ b/packages/pyright-internal/src/tests/sourceFile.test.ts
@@ -18,6 +18,7 @@ import { createServiceProvider } from '../common/serviceProviderExtensions';
 import { Uri } from '../common/uri/uri';
 import { parseAndGetTestState } from './harness/fourslash/testState';
 import { BaselineHandler } from '../baseline';
+import { tExpect } from 'typed-jest-expect';
 
 test('Empty', () => {
     const filePath = combinePaths(process.cwd(), 'tests/samples/test_file1.py');
@@ -96,7 +97,7 @@ test('Empty Open file', () => {
     assert.strictEqual(state.workspace.service.test_program.getSourceFile(marker.fileUri)?.getFileContent(), '');
 });
 
-test('No unexpected user files', () => {
+describe('no builtin libraries should be treated as user code', () => {
     const code = `
 // @filename: pyrightconfig.json
 //// {
@@ -111,7 +112,19 @@ test('No unexpected user files', () => {
     const marker = state.getMarkerByName('marker');
     while (state.workspace.service.test_program.analyze());
 
-    const userFiles = state.workspace.service.test_program.getUserFiles();
-    assert.strictEqual(userFiles.length, 1);
-    assert.strictEqual(userFiles[0].uri.toString(), marker.fileUri.toString());
+    test('No unexpected user files', () => {
+        const userFiles = state.workspace.service.test_program.getUserFiles();
+        assert.strictEqual(userFiles.length, 1);
+        assert.strictEqual(userFiles[0].uri.toString(), marker.fileUri.toString());
+    });
+
+    test('No unexpected files with diagnostics', () => {
+        const tempFile = new RealTempFile();
+        const fs = createFromRealFileSystem(tempFile);
+        const serviceProvider = createServiceProvider(tempFile, fs);
+        const configOptions = new ConfigOptions(Uri.file(process.cwd(), serviceProvider));
+        const fileDiagnostics = state.workspace.service.test_program.getDiagnostics(configOptions);
+        tExpect(fileDiagnostics.length).toBe(1);
+        tExpect(fileDiagnostics[0].fileUri.toString()).toBe(marker.fileUri.toString());
+    });
 });


### PR DESCRIPTION
fixes #1677