### PR TITLE
Fix/issue 545 auto import unbound files

### DIFF
--- a/packages/pyright-internal/src/common/extensibility.ts
+++ b/packages/pyright-internal/src/common/extensibility.ts
@@ -89,6 +89,7 @@ export interface ProgramView {
     getParserOutput(fileUri: Uri): ParserOutput | undefined;
     getParseResults(fileUri: Uri): ParseFileResults | undefined;
     getSourceFileInfo(fileUri: Uri): SourceFileInfo | undefined;
+    getBoundSourceFileInfo(uri: Uri, content?: string, force?: boolean): SourceFileInfo | undefined;
     getModuleSymbolTable(fileUri: Uri): SymbolTable | undefined;
     getChainedUri(fileUri: Uri): Uri | undefined;
     getSourceMapper(fileUri: Uri, token: CancellationToken, mapCompiled?: boolean, preferStubs?: boolean): SourceMapper;

--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1231,7 +1231,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
             const currentFile = program.getSourceFileInfo(uri);
             const moduleSymbolMap = buildModuleSymbolsMap(
                 program,
-                program.getSourceFileInfoList().filter((s) => s !== currentFile)
+                program.getSourceFileInfoList().filter((s) => s !== currentFile),
+                token
             );
 
             const parseFileResults = program.getParseResults(uri);

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -143,11 +143,16 @@ function getModuleSymbolTableForAutoImport(
 export function buildModuleSymbolsMap(
     program: ProgramView,
     files: readonly SourceFileInfo[],
+    token: CancellationToken,
     options: ModuleSymbolMapOptions = {}
 ): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, ModuleSymbolTable>();
 
     files.forEach((file) => {
+        // Binding unbound files (see getModuleSymbolTableForAutoImport) can be expensive
+        // on large workspaces, so honor cancellation between files.
+        throwIfCancellationRequested(token);
+
         if (file.shadows.length > 0) {
             // There is corresponding stub file. Don't add
             // duplicated files in the map.

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -23,7 +23,7 @@ import {
     getTopLevelImports,
 } from '../analyzer/importStatementUtils';
 import { isUserCode } from '../analyzer/sourceFileInfoUtils';
-import { Symbol } from '../analyzer/symbol';
+import { Symbol, SymbolTable } from '../analyzer/symbol';
 import * as SymbolNameUtils from '../analyzer/symbolNameUtils';
 import { isVisibleExternally } from '../analyzer/symbolUtils';
 import { throwIfCancellationRequested } from '../common/cancellationUtils';
@@ -114,9 +114,37 @@ export interface ImportAliasData {
 
 export type AutoImportResultMap = Map<string, AutoImportResult[]>;
 
+export interface ModuleSymbolMapOptions {
+    readonly bindUnboundUserCode?: boolean;
+}
+
+function getModuleSymbolTableForAutoImport(
+    program: ProgramView,
+    file: SourceFileInfo,
+    options: ModuleSymbolMapOptions
+): SymbolTable | undefined {
+    let symbolTable = program.getModuleSymbolTable(file.uri);
+    if (symbolTable) {
+        return symbolTable;
+    }
+
+    // Tracked workspace files might not be bound yet if they haven't been opened or
+    // analyzed. Bind them so auto-import completions can find their symbols.
+    if (options.bindUnboundUserCode && isUserCode(file) && file.isTracked) {
+        program.getParseResults(file.uri);
+        symbolTable = program.getModuleSymbolTable(file.uri);
+    }
+
+    return symbolTable;
+}
+
 // Build a map of all modules within this program and the module-
 // level scope that contains the symbol table for the module.
-export function buildModuleSymbolsMap(program: ProgramView, files: readonly SourceFileInfo[]): ModuleSymbolMap {
+export function buildModuleSymbolsMap(
+    program: ProgramView,
+    files: readonly SourceFileInfo[],
+    options: ModuleSymbolMapOptions = {}
+): ModuleSymbolMap {
     const moduleSymbolMap = new Map<string, ModuleSymbolTable>();
 
     files.forEach((file) => {
@@ -127,7 +155,7 @@ export function buildModuleSymbolsMap(program: ProgramView, files: readonly Sour
         }
 
         const uri = file.uri;
-        const symbolTable = program.getModuleSymbolTable(uri);
+        const symbolTable = getModuleSymbolTableForAutoImport(program, file, options);
         if (!symbolTable) {
             return;
         }

--- a/packages/pyright-internal/src/languageService/autoImporter.ts
+++ b/packages/pyright-internal/src/languageService/autoImporter.ts
@@ -130,8 +130,8 @@ function getModuleSymbolTableForAutoImport(
 
     // Tracked workspace files might not be bound yet if they haven't been opened or
     // analyzed. Bind them so auto-import completions can find their symbols.
-    if (options.bindUnboundUserCode && isUserCode(file) && file.isTracked) {
-        program.getParseResults(file.uri);
+    if (options.bindUnboundUserCode && isUserCode(file)) {
+        program.getBoundSourceFileInfo(file.uri);
         symbolTable = program.getModuleSymbolTable(file.uri);
     }
 

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -418,7 +418,8 @@ export class CompletionProvider {
         const currentFile = this.program.getSourceFileInfo(this.fileUri);
         const moduleSymbolMap = buildModuleSymbolsMap(
             this.program,
-            this.program.getSourceFileInfoList().filter((s) => s !== currentFile)
+            this.program.getSourceFileInfoList().filter((s) => s !== currentFile),
+            { bindUnboundUserCode: true }
         );
 
         return new AutoImporter(

--- a/packages/pyright-internal/src/languageService/completionProvider.ts
+++ b/packages/pyright-internal/src/languageService/completionProvider.ts
@@ -419,6 +419,7 @@ export class CompletionProvider {
         const moduleSymbolMap = buildModuleSymbolsMap(
             this.program,
             this.program.getSourceFileInfoList().filter((s) => s !== currentFile),
+            this.cancellationToken,
             { bindUnboundUserCode: true }
         );
 

--- a/packages/pyright-internal/src/tests/autoImporter.test.ts
+++ b/packages/pyright-internal/src/tests/autoImporter.test.ts
@@ -4,16 +4,20 @@
  */
 
 import * as assert from 'assert';
+import { CancellationToken } from 'vscode-languageserver';
 
 import { ImportResolver } from '../analyzer/importResolver';
 import { Program } from '../analyzer/program';
 import { IPythonMode } from '../analyzer/sourceFile';
 import { ConfigOptions } from '../common/configOptions';
 import { normalizeSlashes } from '../common/pathUtils';
+import { convertOffsetToPosition } from '../common/positionUtils';
 import { createServiceProvider } from '../common/serviceProviderExtensions';
 import { UriEx } from '../common/uri/uriUtils';
 import { buildModuleSymbolsMap } from '../languageService/autoImporter';
+import { CompletionOptions, CompletionProvider } from '../languageService/completionProvider';
 import { PyrightFileSystem } from '../pyrightFileSystem';
+import { parseAndGetTestState } from './harness/fourslash/testState';
 import { TestAccessHost } from './harness/testAccessHost';
 import { TestFileSystem } from './harness/vfs/filesystem';
 
@@ -78,11 +82,13 @@ test('buildModuleSymbolsMap includes symbols from unbound tracked workspace file
     assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
 
     const mod1Info = program.getSourceFileInfo(mod1Uri)!;
-    const defaultModuleSymbolMap = buildModuleSymbolsMap(program, [mod1Info]);
+    const defaultModuleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], CancellationToken.None);
     assert.strictEqual(defaultModuleSymbolMap.size, 0);
     assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
 
-    const moduleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], { bindUnboundUserCode: true });
+    const moduleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], CancellationToken.None, {
+        bindUnboundUserCode: true,
+    });
 
     let foundSomeFunction = false;
     moduleSymbolMap.forEach((table) => {
@@ -100,4 +106,56 @@ test('buildModuleSymbolsMap includes symbols from unbound tracked workspace file
     );
 
     program.dispose();
+});
+
+test('CompletionProvider surfaces auto-imports from unopened tracked workspace files', () => {
+    // End-to-end coverage for the call site in completionProvider.ts that opts into
+    // bindUnboundUserCode. Removing that opt-in would silently regress this scenario
+    // even though the lower-level buildModuleSymbolsMap test would still pass.
+    const code = `
+// @filename: test.py
+//// some_func/*marker*/
+
+// @filename: mod_unopened.py
+//// def some_function(arg: str):
+////     ...
+    `;
+
+    const state = parseAndGetTestState(code).state;
+    const marker = state.getMarkerByName('marker');
+    const markerFile = state.testData.files.find((f) => f.fileName === marker.fileName)!;
+    const unopenedFile = state.testData.files.find((f) => f.fileName !== marker.fileName)!;
+
+    // Sanity check: only the marker file has been opened, so the tracked-but-unopened
+    // file has no module symbol table yet. This is the scenario that previously hid
+    // workspace symbols from auto-import completions (issue #545).
+    assert.strictEqual(state.program.getModuleSymbolTable(unopenedFile.fileUri), undefined);
+
+    const parseResult = state.program.getParseResults(markerFile.fileUri)!;
+    const position = convertOffsetToPosition(marker.position, parseResult.tokenizerOutput.lines);
+
+    const options: CompletionOptions = {
+        format: 'markdown',
+        snippet: false,
+        lazyEdit: false,
+        checkDeprecatedWhenResolving: false,
+        useTypingExtensions: false,
+    };
+
+    const result = new CompletionProvider(
+        state.program,
+        markerFile.fileUri,
+        position,
+        options,
+        CancellationToken.None,
+        /* codeActions */ false
+    ).getCompletions();
+
+    assert.ok(result);
+    const item = result.items.find((i) => i.label === 'some_function' && i.detail === 'Auto-import');
+    assert.ok(item, 'expected auto-import completion for some_function from an unopened tracked file');
+    assert.ok(
+        item.additionalTextEdits?.some((e) => e.newText.includes('from mod_unopened import some_function')),
+        'expected auto-import edit "from mod_unopened import some_function"'
+    );
 });

--- a/packages/pyright-internal/src/tests/autoImporter.test.ts
+++ b/packages/pyright-internal/src/tests/autoImporter.test.ts
@@ -1,0 +1,103 @@
+/*
+ * autoImporter.test.ts
+ * Tests for auto-import completion logic.
+ */
+
+import * as assert from 'assert';
+
+import { ImportResolver } from '../analyzer/importResolver';
+import { Program } from '../analyzer/program';
+import { IPythonMode } from '../analyzer/sourceFile';
+import { ConfigOptions } from '../common/configOptions';
+import { normalizeSlashes } from '../common/pathUtils';
+import { createServiceProvider } from '../common/serviceProviderExtensions';
+import { UriEx } from '../common/uri/uriUtils';
+import { buildModuleSymbolsMap } from '../languageService/autoImporter';
+import { PyrightFileSystem } from '../pyrightFileSystem';
+import { TestAccessHost } from './harness/testAccessHost';
+import { TestFileSystem } from './harness/vfs/filesystem';
+
+function createTestFileSystem(files: { path: string; content: string }[]): TestFileSystem {
+    const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
+
+    for (const file of files) {
+        fs.mkdirpSync(normalizeSlashes(file.path).replace(/\/[^/]+$/, ''));
+        fs.writeFileSync(UriEx.file(normalizeSlashes(file.path)), file.content);
+    }
+
+    return fs;
+}
+
+test('buildModuleSymbolsMap includes symbols from unbound tracked workspace files', () => {
+    const projectRoot = normalizeSlashes('/project');
+    const files = [
+        {
+            path: `${projectRoot}/pack1/__init__.py`,
+            content: '',
+        },
+        {
+            path: `${projectRoot}/pack1/mod1.py`,
+            content: 'def some_function(arg: str):\n    ...\n',
+        },
+        {
+            path: `${projectRoot}/pack2/__init__.py`,
+            content: '',
+        },
+        {
+            path: `${projectRoot}/pack2/mod2.py`,
+            content: '# empty\n',
+        },
+    ];
+
+    const testFS = createTestFileSystem(files);
+    const fs = new PyrightFileSystem(testFS);
+    const serviceProvider = createServiceProvider(testFS, fs);
+    const configOptions = new ConfigOptions(UriEx.file(projectRoot));
+    configOptions.autoImportCompletions = true;
+    configOptions.internalTestMode = true;
+
+    const importResolver = new ImportResolver(
+        serviceProvider,
+        configOptions,
+        new TestAccessHost(serviceProvider.fs().getModulePath(), [])
+    );
+    const program = new Program(importResolver, configOptions, serviceProvider);
+
+    const mod1Uri = UriEx.file(`${projectRoot}/pack1/mod1.py`);
+    const mod2Uri = UriEx.file(`${projectRoot}/pack2/mod2.py`);
+
+    program.setTrackedFiles([mod1Uri, mod2Uri]);
+    program.setFileOpened(mod2Uri, 1, '# empty\n', {
+        isTracked: true,
+        ipythonMode: IPythonMode.None,
+        chainedFileUri: undefined,
+    });
+
+    // Simulate a session where only the active file has been bound so far.
+    program.getParseResults(mod2Uri);
+    assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
+
+    const mod1Info = program.getSourceFileInfo(mod1Uri)!;
+    const defaultModuleSymbolMap = buildModuleSymbolsMap(program, [mod1Info]);
+    assert.strictEqual(defaultModuleSymbolMap.size, 0);
+    assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
+
+    const moduleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], { bindUnboundUserCode: true });
+
+    let foundSomeFunction = false;
+    moduleSymbolMap.forEach((table) => {
+        for (const symbol of table.getSymbols()) {
+            if (symbol.name === 'some_function') {
+                foundSomeFunction = true;
+            }
+        }
+    });
+
+    assert.strictEqual(
+        foundSomeFunction,
+        true,
+        'Expected some_function from an unbound tracked file to appear in the module symbol map'
+    );
+
+    program.dispose();
+});

--- a/packages/pyright-internal/src/tests/autoImporter.test.ts
+++ b/packages/pyright-internal/src/tests/autoImporter.test.ts
@@ -3,115 +3,14 @@
  * Tests for auto-import completion logic.
  */
 
-import * as assert from 'assert';
 import { CancellationToken } from 'vscode-languageserver';
+import { tExpect } from 'typed-jest-expect';
 
-import { ImportResolver } from '../analyzer/importResolver';
-import { Program } from '../analyzer/program';
-import { IPythonMode } from '../analyzer/sourceFile';
-import { ConfigOptions } from '../common/configOptions';
-import { normalizeSlashes } from '../common/pathUtils';
 import { convertOffsetToPosition } from '../common/positionUtils';
-import { createServiceProvider } from '../common/serviceProviderExtensions';
-import { UriEx } from '../common/uri/uriUtils';
-import { buildModuleSymbolsMap } from '../languageService/autoImporter';
 import { CompletionOptions, CompletionProvider } from '../languageService/completionProvider';
-import { PyrightFileSystem } from '../pyrightFileSystem';
 import { parseAndGetTestState } from './harness/fourslash/testState';
-import { TestAccessHost } from './harness/testAccessHost';
-import { TestFileSystem } from './harness/vfs/filesystem';
-
-function createTestFileSystem(files: { path: string; content: string }[]): TestFileSystem {
-    const fs = new TestFileSystem(/* ignoreCase */ false, { cwd: normalizeSlashes('/') });
-
-    for (const file of files) {
-        fs.mkdirpSync(normalizeSlashes(file.path).replace(/\/[^/]+$/, ''));
-        fs.writeFileSync(UriEx.file(normalizeSlashes(file.path)), file.content);
-    }
-
-    return fs;
-}
-
-test('buildModuleSymbolsMap includes symbols from unbound tracked workspace files', () => {
-    const projectRoot = normalizeSlashes('/project');
-    const files = [
-        {
-            path: `${projectRoot}/pack1/__init__.py`,
-            content: '',
-        },
-        {
-            path: `${projectRoot}/pack1/mod1.py`,
-            content: 'def some_function(arg: str):\n    ...\n',
-        },
-        {
-            path: `${projectRoot}/pack2/__init__.py`,
-            content: '',
-        },
-        {
-            path: `${projectRoot}/pack2/mod2.py`,
-            content: '# empty\n',
-        },
-    ];
-
-    const testFS = createTestFileSystem(files);
-    const fs = new PyrightFileSystem(testFS);
-    const serviceProvider = createServiceProvider(testFS, fs);
-    const configOptions = new ConfigOptions(UriEx.file(projectRoot));
-    configOptions.autoImportCompletions = true;
-    configOptions.internalTestMode = true;
-
-    const importResolver = new ImportResolver(
-        serviceProvider,
-        configOptions,
-        new TestAccessHost(serviceProvider.fs().getModulePath(), [])
-    );
-    const program = new Program(importResolver, configOptions, serviceProvider);
-
-    const mod1Uri = UriEx.file(`${projectRoot}/pack1/mod1.py`);
-    const mod2Uri = UriEx.file(`${projectRoot}/pack2/mod2.py`);
-
-    program.setTrackedFiles([mod1Uri, mod2Uri]);
-    program.setFileOpened(mod2Uri, 1, '# empty\n', {
-        isTracked: true,
-        ipythonMode: IPythonMode.None,
-        chainedFileUri: undefined,
-    });
-
-    // Simulate a session where only the active file has been bound so far.
-    program.getParseResults(mod2Uri);
-    assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
-
-    const mod1Info = program.getSourceFileInfo(mod1Uri)!;
-    const defaultModuleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], CancellationToken.None);
-    assert.strictEqual(defaultModuleSymbolMap.size, 0);
-    assert.strictEqual(program.getModuleSymbolTable(mod1Uri), undefined);
-
-    const moduleSymbolMap = buildModuleSymbolsMap(program, [mod1Info], CancellationToken.None, {
-        bindUnboundUserCode: true,
-    });
-
-    let foundSomeFunction = false;
-    moduleSymbolMap.forEach((table) => {
-        for (const symbol of table.getSymbols()) {
-            if (symbol.name === 'some_function') {
-                foundSomeFunction = true;
-            }
-        }
-    });
-
-    assert.strictEqual(
-        foundSomeFunction,
-        true,
-        'Expected some_function from an unbound tracked file to appear in the module symbol map'
-    );
-
-    program.dispose();
-});
 
 test('CompletionProvider surfaces auto-imports from unopened tracked workspace files', () => {
-    // End-to-end coverage for the call site in completionProvider.ts that opts into
-    // bindUnboundUserCode. Removing that opt-in would silently regress this scenario
-    // even though the lower-level buildModuleSymbolsMap test would still pass.
     const code = `
 // @filename: test.py
 //// some_func/*marker*/
@@ -129,7 +28,7 @@ test('CompletionProvider surfaces auto-imports from unopened tracked workspace f
     // Sanity check: only the marker file has been opened, so the tracked-but-unopened
     // file has no module symbol table yet. This is the scenario that previously hid
     // workspace symbols from auto-import completions (issue #545).
-    assert.strictEqual(state.program.getModuleSymbolTable(unopenedFile.fileUri), undefined);
+    tExpect(state.program.getModuleSymbolTable(unopenedFile.fileUri)).toBeUndefined();
 
     const parseResult = state.program.getParseResults(markerFile.fileUri)!;
     const position = convertOffsetToPosition(marker.position, parseResult.tokenizerOutput.lines);
@@ -151,11 +50,10 @@ test('CompletionProvider surfaces auto-imports from unopened tracked workspace f
         /* codeActions */ false
     ).getCompletions();
 
-    assert.ok(result);
-    const item = result.items.find((i) => i.label === 'some_function' && i.detail === 'Auto-import');
-    assert.ok(item, 'expected auto-import completion for some_function from an unopened tracked file');
-    assert.ok(
-        item.additionalTextEdits?.some((e) => e.newText.includes('from mod_unopened import some_function')),
-        'expected auto-import edit "from mod_unopened import some_function"'
+    tExpect(result).not.toBeNull();
+    const item = result!.items.find((i) => i.label === 'some_function' && i.detail === 'Auto-import');
+    tExpect(item).toBeDefined();
+    tExpect(item!.additionalTextEdits?.some((e) => e.newText.includes('from mod_unopened import some_function'))).toBe(
+        true
     );
 });


### PR DESCRIPTION
Fixes #545

This makes auto-import completions bind tracked workspace files on demand when they have not yet been opened or analyzed. This way symbols from unopened workspace modules can still appear in completion results.

Tested:
  - npx jest autoImporter.test --runInBand
  - npm run build
  - npx eslint src/languageService/autoImporter.ts src/languageService/completionProvider.ts src/tests/autoImporter.test.ts
  - npx prettier -c src/languageService/autoImporter.ts src/languageService/completionProvider.ts src/tests/
  autoImporter.test.ts
  - npx jest fourSlashRunner.test --runInBand --testNamePattern completions.autoimport.fourslash