### PR TITLE
avoid duplicate capability registrations

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -822,7 +822,6 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 this.connection.workspace.onDidChangeWorkspaceFolders(changeWorkspaceFolderHandler);
         }
 
-        this.dynamicFeatures.register();
         this.updateSettingsForAllWorkspaces();
     }
 

--- a/packages/pyright-internal/src/languageService/dynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/dynamicFeature.ts
@@ -17,8 +17,10 @@ export abstract class DynamicFeature {
 
     register() {
         this.registerFeature().then((d) => {
-            this.dispose();
-            this._lastRegistration = d;
+            if (d) {
+                this.dispose();
+                this._lastRegistration = d;
+            }
         });
     }
 
@@ -37,7 +39,7 @@ export abstract class DynamicFeature {
         this.dispose();
     }
 
-    protected abstract registerFeature(): Promise<Disposable>;
+    protected abstract registerFeature(): Promise<Disposable | null>;
 }
 
 export class DynamicFeatures {

--- a/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
@@ -20,7 +20,7 @@ import { isDefined } from '../common/core';
 import { configFileName } from '../common/pathConsts';
 
 export class FileWatcherDynamicFeature extends DynamicFeature {
-    private _lastRegistrationHash: string[] = [];
+    private _lastRegistrationHash: string | undefined;
 
     constructor(
         private readonly _connection: Connection,
@@ -33,7 +33,7 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
 
     override disable() {
         super.disable();
-        this._lastRegistrationHash = [];
+        this._lastRegistrationHash = undefined;
     }
 
     protected override registerFeature(): Promise<Disposable | null> {
@@ -77,8 +77,7 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
         }
 
         const registrationHash = this._createRegistrationHash(watchers);
-        if (registrationHash.length === this._lastRegistrationHash.length
-            && registrationHash.every((item, index) => item === this._lastRegistrationHash[index])) {
+        if (registrationHash !== this._lastRegistrationHash) {
             return Promise.resolve(null);
         }
 
@@ -86,8 +85,8 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
         return this._connection.client.register(DidChangeWatchedFilesNotification.type, { watchers });
     }
 
-    private _createRegistrationHash(watchers: FileSystemWatcher[]): string[] {
-        return watchers.map(watcher => `${JSON.stringify(watcher.globPattern)}:${watcher.kind}`);
+    private _createRegistrationHash(watchers: FileSystemWatcher[]): string {
+        return JSON.stringify(watchers.map(watcher => `${JSON.stringify(watcher.globPattern)}:${watcher.kind}`));
     }
 }
 

--- a/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
@@ -20,6 +20,8 @@ import { isDefined } from '../common/core';
 import { configFileName } from '../common/pathConsts';
 
 export class FileWatcherDynamicFeature extends DynamicFeature {
+    private _last_registration_fingerprint: string[] = [];
+
     constructor(
         private readonly _connection: Connection,
         private readonly _hasWatchFileRelativePathCapability: boolean,
@@ -29,7 +31,12 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
         super('file watcher');
     }
 
-    protected override registerFeature(): Promise<Disposable> {
+    override disable() {
+        super.disable();
+        this._last_registration_fingerprint = [];
+    }
+
+    protected override registerFeature(): Promise<Disposable | null> {
         const watchKind = WatchKind.Create | WatchKind.Change | WatchKind.Delete;
 
         // Set default (config files and all workspace files) first.
@@ -69,7 +76,18 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
             });
         }
 
+        const registration_fingerprint = this.createRegistrationFingerprint(watchers);
+        if (registration_fingerprint.length === this._last_registration_fingerprint.length
+            && registration_fingerprint.every((item, index) => item === this._last_registration_fingerprint[index])) {
+            return Promise.resolve(null);
+        }
+
+        this._last_registration_fingerprint = registration_fingerprint;
         return this._connection.client.register(DidChangeWatchedFilesNotification.type, { watchers });
+    }
+
+    private createRegistrationFingerprint(watchers: FileSystemWatcher[]): string[] {
+        return watchers.map(watcher => `${JSON.stringify(watcher.globPattern)}:${watcher.kind}`);
     }
 }
 

--- a/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/fileWatcherDynamicFeature.ts
@@ -20,7 +20,7 @@ import { isDefined } from '../common/core';
 import { configFileName } from '../common/pathConsts';
 
 export class FileWatcherDynamicFeature extends DynamicFeature {
-    private _last_registration_fingerprint: string[] = [];
+    private _lastRegistrationHash: string[] = [];
 
     constructor(
         private readonly _connection: Connection,
@@ -33,7 +33,7 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
 
     override disable() {
         super.disable();
-        this._last_registration_fingerprint = [];
+        this._lastRegistrationHash = [];
     }
 
     protected override registerFeature(): Promise<Disposable | null> {
@@ -76,17 +76,17 @@ export class FileWatcherDynamicFeature extends DynamicFeature {
             });
         }
 
-        const registration_fingerprint = this.createRegistrationFingerprint(watchers);
-        if (registration_fingerprint.length === this._last_registration_fingerprint.length
-            && registration_fingerprint.every((item, index) => item === this._last_registration_fingerprint[index])) {
+        const registrationHash = this._createRegistrationHash(watchers);
+        if (registrationHash.length === this._lastRegistrationHash.length
+            && registrationHash.every((item, index) => item === this._lastRegistrationHash[index])) {
             return Promise.resolve(null);
         }
 
-        this._last_registration_fingerprint = registration_fingerprint;
+        this._lastRegistrationHash = registrationHash;
         return this._connection.client.register(DidChangeWatchedFilesNotification.type, { watchers });
     }
 
-    private createRegistrationFingerprint(watchers: FileSystemWatcher[]): string[] {
+    private _createRegistrationHash(watchers: FileSystemWatcher[]): string[] {
         return watchers.map(watcher => `${JSON.stringify(watcher.globPattern)}:${watcher.kind}`);
     }
 }

--- a/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
@@ -16,6 +16,7 @@ import { ServerSettings } from '../common/languageServerInterface';
 export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     private _workspaceSupport = false;
     private _registered = false;
+    private _last_registration_fingerprint: string = '';
 
     constructor(private readonly _connection: Connection, private readonly _id: string = 'pyright') {
         super('pull diagnostics');
@@ -24,6 +25,7 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     override disable() {
         super.disable();
         this._registered = false;
+        this._last_registration_fingerprint = '';
     }
 
     override update(settings: ServerSettings): void {
@@ -38,7 +40,7 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
         }
     }
 
-    protected override registerFeature(): Promise<Disposable> {
+    protected override registerFeature(): Promise<Disposable | null> {
         this._registered = true;
         const options: DiagnosticRegistrationOptions = {
             interFileDependencies: true,
@@ -46,6 +48,13 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
             documentSelector: null,
             identifier: this._id,
         };
+
+        const registration_fingerprint = JSON.stringify(options);
+        if (registration_fingerprint === this._last_registration_fingerprint) {
+            return Promise.resolve(null);
+        }
+
+        this._last_registration_fingerprint = registration_fingerprint;
         return this._connection.client.register(DocumentDiagnosticRequest.type, options);
     }
 }

--- a/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
@@ -16,7 +16,7 @@ import { ServerSettings } from '../common/languageServerInterface';
 export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     private _workspaceSupport = false;
     private _registered = false;
-    private _lastRegistrationHash: string = '';
+    private _lastRegistrationHash: string | undefined;
 
     constructor(private readonly _connection: Connection, private readonly _id: string = 'pyright') {
         super('pull diagnostics');
@@ -25,7 +25,7 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     override disable() {
         super.disable();
         this._registered = false;
-        this._lastRegistrationHash = '';
+        this._lastRegistrationHash = undefined;
     }
 
     override update(settings: ServerSettings): void {
@@ -49,12 +49,12 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
             identifier: this._id,
         };
 
-        const registration_fingerprint = JSON.stringify(options);
-        if (registration_fingerprint === this._lastRegistrationHash) {
+        const registrationHash = JSON.stringify(options);
+        if (registrationHash === this._lastRegistrationHash) {
             return Promise.resolve(null);
         }
 
-        this._lastRegistrationHash = registration_fingerprint;
+        this._lastRegistrationHash = registrationHash;
         return this._connection.client.register(DocumentDiagnosticRequest.type, options);
     }
 }

--- a/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
+++ b/packages/pyright-internal/src/languageService/pullDiagnosticsDynamicFeature.ts
@@ -16,7 +16,7 @@ import { ServerSettings } from '../common/languageServerInterface';
 export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     private _workspaceSupport = false;
     private _registered = false;
-    private _last_registration_fingerprint: string = '';
+    private _lastRegistrationHash: string = '';
 
     constructor(private readonly _connection: Connection, private readonly _id: string = 'pyright') {
         super('pull diagnostics');
@@ -25,7 +25,7 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
     override disable() {
         super.disable();
         this._registered = false;
-        this._last_registration_fingerprint = '';
+        this._lastRegistrationHash = '';
     }
 
     override update(settings: ServerSettings): void {
@@ -50,11 +50,11 @@ export class PullDiagnosticsDynamicFeature extends DynamicFeature {
         };
 
         const registration_fingerprint = JSON.stringify(options);
-        if (registration_fingerprint === this._last_registration_fingerprint) {
+        if (registration_fingerprint === this._lastRegistrationHash) {
             return Promise.resolve(null);
         }
 
-        this._last_registration_fingerprint = registration_fingerprint;
+        this._lastRegistrationHash = registration_fingerprint;
         return this._connection.client.register(DocumentDiagnosticRequest.type, options);
     }
 }


### PR DESCRIPTION
Make capability registration optionally return null, which signifies that the registration has not been performed due to the feature already being registered.

This is determined by comparing registration options with an already-registered feature - if those are the same, then it's deemed unnecessary to re-register the feature. That results in not doing unnecessary re-registrations for already-registered features.

Addressed for both `textDocument/diagnostic` and `workspace/didChangeWatchedFiles`.

I did think that maybe doing the re-registration of an already-registered feature is a way of telling the client that it needs to re-request diagnostics (for example), but it does call `workspace/diagnostic/refresh` when needed, so it doesn't appear to be the case. And for `workspace/didChangeWatchedFiles`, there is nothing that needs to be done anyway.

Fixes #1808