### PR TITLE
fix: clarify implicit abstract class diagnostic

### DIFF
--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -492,7 +492,7 @@
             "message": "Class \"{type}\" is marked final and must implement all abstract symbols",
             "comment": "{Locked='final'}"
         },
-        "classImplicitlyAbstract": "Class \"{type}\" is implicitly abstract because it extends an abstract class without implementing all abstract symbols. If this is intentional, add `ABC` to its base classes or use `metaclass=ABCMeta`.",
+        "classImplicitlyAbstract": "Class \"{type}\" is implicitly abstract because it extends an abstract class but still contains abstract symbols. If this is intentional, add `ABC` to its base classes or use `metaclass=ABCMeta`.",
         "classImplicitlyProtocol": "Class \"{type}\" is implicitly a `Protocol` because it extends a `Protocol` without implementing all abstract symbols. If this is intentional, add `Protocol` or `ABC` to its base classes, or use `metaclass=ABCMeta`.",
         "finalContext": {
             "message": "\"Final\" is not allowed in this context",

--- a/packages/pyright-internal/src/tests/checker.test.ts
+++ b/packages/pyright-internal/src/tests/checker.test.ts
@@ -813,8 +813,19 @@ test('reportImplicitAbstractClass', () => {
     const analysisResults = TestUtils.typeAnalyzeSampleFiles(['implicitAbstractClass.py'], configOptions);
     TestUtils.validateResultsButBased(analysisResults, {
         errors: [
-            { code: DiagnosticRule.reportImplicitAbstractClass, line: 7 },
+            {
+                code: DiagnosticRule.reportImplicitAbstractClass,
+                line: 7,
+                message:
+                    'Class "B" is implicitly abstract because it extends an abstract class but still contains abstract symbols. If this is intentional, add `ABC` to its base classes or use `metaclass=ABCMeta`.\n  "A.asdf" is not implemented',
+            },
             { code: DiagnosticRule.reportImplicitAbstractClass, line: 25 },
+            {
+                code: DiagnosticRule.reportImplicitAbstractClass,
+                line: 33,
+                message:
+                    'Class "J" is implicitly abstract because it extends an abstract class but still contains abstract symbols. If this is intentional, add `ABC` to its base classes or use `metaclass=ABCMeta`.\n  "J.asdf" is not implemented',
+            },
         ],
     });
 });

--- a/packages/pyright-internal/src/tests/samples/implicitAbstractClass.py
+++ b/packages/pyright-internal/src/tests/samples/implicitAbstractClass.py
@@ -28,3 +28,9 @@ class G(F): # error
 
 class H(F, Protocol):
     pass
+
+class I(ABC): ...
+
+class J(I): # error
+    @abstractmethod
+    def asdf(self) -> int: ...


### PR DESCRIPTION
## Summary

Fixes #1747 by clarifying the `reportImplicitAbstractClass` diagnostic so it does not imply that the missing abstract symbol must come from the parent abstract class.

## Reproduction

The issue example is a class that extends an abstract base and declares a new abstract method itself:

```python
from abc import ABC, abstractmethod

class A(ABC): ...

class B(A):
    @abstractmethod
    def f(self): ...
```

The previous wording said the class extends an abstract class “without implementing all abstract symbols,” which can read as if the missing abstract symbol necessarily belongs to the base class.

## Root cause

The diagnostic message was correct for some cases, but too narrow for classes that still contain abstract symbols introduced on the subclass itself.

## Changes

- Update the English `classImplicitlyAbstract` diagnostic wording to say the class still contains abstract symbols.
- Add a sample case where the subclass introduces an abstract method.
- Assert the updated diagnostic message for both an inherited abstract symbol and a subclass-defined abstract symbol.

## Tests

- `git diff --check`
- `cd packages/pyright-internal && node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest checker.test.ts -t reportImplicitAbstractClass --runInBand --forceExit`
- `npm run typecheck`
- `npx prettier -c packages/pyright-internal/src/localization/package.nls.en-us.json packages/pyright-internal/src/tests/checker.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint packages/pyright-internal/src/tests/checker.test.ts`

## Screenshots/Logs

N/A
