### PR TITLE
fix: suppress unused call result for notebook cell value

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -827,7 +827,7 @@ export class Checker extends ParseTreeWalker {
             this._fileInfo.diagnosticRuleSet.reportUnusedCallResult !== 'none' ||
             this._fileInfo.diagnosticRuleSet.reportUnusedCoroutine !== 'none'
         ) {
-            if (node.parent?.nodeType === ParseNodeType.StatementList) {
+            if (node.parent?.nodeType === ParseNodeType.StatementList && !this._isLastStatementInNotebookCell(node)) {
                 const isRevealTypeCall =
                     node.d.leftExpr.nodeType === ParseNodeType.Name && node.d.leftExpr.d.value === 'reveal_type';
                 const returnType = this._evaluator.getType(node);
@@ -860,7 +860,11 @@ export class Checker extends ParseTreeWalker {
 
     override visitAwait(node: AwaitNode) {
         if (this._fileInfo.diagnosticRuleSet.reportUnusedCallResult !== 'none') {
-            if (node.parent?.nodeType === ParseNodeType.StatementList && node.d.expr.nodeType === ParseNodeType.Call) {
+            if (
+                node.parent?.nodeType === ParseNodeType.StatementList &&
+                node.d.expr.nodeType === ParseNodeType.Call &&
+                !this._isLastStatementInNotebookCell(node)
+            ) {
                 const returnType = this._evaluator.getType(node);
 
                 if (returnType && this._isTypeValidForUnusedValueTest(returnType)) {
@@ -1996,14 +2000,7 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
-        if (
-            reportAsUnused &&
-            this._fileInfo.ipythonMode === IPythonMode.CellDocs &&
-            node.parent?.nodeType === ParseNodeType.StatementList &&
-            node.parent.d.statements[node.parent.d.statements.length - 1] === node &&
-            node.parent.parent?.nodeType === ParseNodeType.Module &&
-            node.parent.parent.d.statements[node.parent.parent.d.statements.length - 1] === node.parent
-        ) {
+        if (reportAsUnused && this._isLastStatementInNotebookCell(node)) {
             // Exclude an expression at the end of a notebook cell, as that is treated as
             // the cell's value.
             reportAsUnused = false;
@@ -2012,6 +2009,16 @@ export class Checker extends ParseTreeWalker {
         if (reportAsUnused) {
             this._evaluator.addDiagnostic(DiagnosticRule.reportUnusedExpression, LocMessage.unusedExpression(), node);
         }
+    }
+
+    private _isLastStatementInNotebookCell(node: ParseNode) {
+        return (
+            this._fileInfo.ipythonMode === IPythonMode.CellDocs &&
+            node.parent?.nodeType === ParseNodeType.StatementList &&
+            node.parent.d.statements[node.parent.d.statements.length - 1] === node &&
+            node.parent.parent?.nodeType === ParseNodeType.Module &&
+            node.parent.parent.d.statements[node.parent.parent.d.statements.length - 1] === node.parent
+        );
     }
 
     // Verifies that the target of a nonlocal statement is not a PEP 695-style

--- a/packages/pyright-internal/src/tests/notebooks.test.ts
+++ b/packages/pyright-internal/src/tests/notebooks.test.ts
@@ -1,5 +1,7 @@
 import { tExpect } from 'typed-jest-expect';
+import { ConfigOptions } from '../common/configOptions';
 import { DiagnosticRule } from '../common/diagnosticRules';
+import { Uri } from '../common/uri/uri';
 import { ErrorTrackingNullConsole, typeAnalyzeSampleFiles, validateResultsButBased } from './testUtils';
 
 test('symbol from previous cell', () => {
@@ -39,5 +41,19 @@ test('IPython.display.display automatically imported', () => {
     const analysisResults = typeAnalyzeSampleFiles(['ipython_display_import/notebook.ipynb']);
     validateResultsButBased(analysisResults, {
         errors: [{ code: DiagnosticRule.reportUndefinedVariable, line: 4 }],
+    });
+});
+
+test('unused call result at end of notebook cell', () => {
+    const configOptions = new ConfigOptions(Uri.empty());
+    configOptions.diagnosticRuleSet.reportUnusedCallResult = 'error';
+
+    const analysisResults = typeAnalyzeSampleFiles(['notebookUnusedCallResult.ipynb'], configOptions);
+    tExpect(analysisResults.length).toStrictEqual(2);
+    validateResultsButBased(analysisResults[0], {
+        errors: [],
+    });
+    validateResultsButBased(analysisResults[1], {
+        errors: [{ code: DiagnosticRule.reportUnusedCallResult, line: 0 }],
     });
 });

--- a/packages/pyright-internal/src/tests/samples/notebookUnusedCallResult.ipynb
+++ b/packages/pyright-internal/src/tests/samples/notebookUnusedCallResult.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def returns_int() -> int:\n",
+    "    return 1\n",
+    "\n",
+    "returns_int()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "returns_int()\n",
+    "value = 1"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fixes #1440.

## Summary
Suppress `reportUnusedCallResult` and `reportUnusedCoroutine` diagnostics for the final statement in a notebook cell, matching the existing `reportUnusedExpression` behavior.

## Reproduction
With `reportUnusedCallResult` enabled, a call expression used as the last line of a notebook cell is currently reported as unused even though the notebook treats that expression as the cell value. A non-final call expression in a notebook cell should still report.

## Root cause
The notebook-cell exception only existed inside `_reportUnusedExpression`. The call-result and await-call diagnostic paths checked for top-level statements directly and did not share that notebook final-statement logic.

## Changes
- Extracted `_isLastStatementInNotebookCell` so the notebook final-statement check is shared.
- Applied the check to `visitCall` and `visitAwait`.
- Added a notebook regression sample and test coverage for both suppressed final-cell calls and reported non-final calls.

## Tests
- `./pw npm run jest -- notebooks.test`
- `./pw npx prettier --check packages/pyright-internal/src/analyzer/checker.ts packages/pyright-internal/src/tests/notebooks.test.ts`
- `git diff --check`

## Screenshots/Logs
Not applicable.