### PR TITLE
Avoid auto f-string conversion for raw strings

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -1748,7 +1748,10 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
         if (
             node?.nodeType === ParseNodeType.String &&
             // other string types that can't be used with f-strings
-            !(node.d.token.flags & (StringTokenFlags.Bytes | StringTokenFlags.Unicode | StringTokenFlags.Template))
+            !(
+                node.d.token.flags &
+                (StringTokenFlags.Bytes | StringTokenFlags.Unicode | StringTokenFlags.Raw | StringTokenFlags.Template)
+            )
         ) {
             // don't do it if the previous characters are "\N{" because the user is likely trying to use a named unicode character, not an f-string
             const dontConvertToFstringIfPrefix = '\\N{';

--- a/packages/pyright-internal/src/tests/languageServer.test.ts
+++ b/packages/pyright-internal/src/tests/languageServer.test.ts
@@ -246,7 +246,8 @@ describe(`Basic language server tests`, () => {
         test('normal string', () => checkOnTypeFormatting({ quoteCount: 1, shouldConvertString: true }));
         test('already f-string', () =>
             checkOnTypeFormatting({ stringPrefix: 'f', quoteCount: 1, shouldConvertString: false }));
-        test('r-string', () => checkOnTypeFormatting({ stringPrefix: 'r', quoteCount: 1, shouldConvertString: true }));
+        test('r-string', () => checkOnTypeFormatting({ stringPrefix: 'r', quoteCount: 1, shouldConvertString: false }));
+        test('R-string', () => checkOnTypeFormatting({ stringPrefix: 'R', quoteCount: 1, shouldConvertString: false }));
         test('bytes', () => checkOnTypeFormatting({ stringPrefix: 'b', quoteCount: 1, shouldConvertString: false }));
         test('t-string', () => checkOnTypeFormatting({ stringPrefix: 't', quoteCount: 1, shouldConvertString: false }));
         test('u-string', () => checkOnTypeFormatting({ stringPrefix: 'u', quoteCount: 1, shouldConvertString: false }));


### PR DESCRIPTION
Summary
- Stop on-type string auto-formatting from converting raw strings to f-strings when `{` is typed.
- Add regression coverage for both `r"..."` and `R"..."` prefixes.

Reproduction
- Enable `basedpyright.analysis.autoFormatStrings`.
- Type `{` inside a raw string such as `r"foo {"` or a raw docstring/regex.
- Before this change, the language server inserts `f` at the start and turns the raw string into an `fr` string.

Root cause
- The on-type formatting guard excluded bytes, unicode, and template strings from f-string conversion, but did not exclude tokens with `StringTokenFlags.Raw`.

Changes
- Include `StringTokenFlags.Raw` in the non-convertible string flags.
- Update the existing `onTypeFormatting` test so raw strings are expected not to convert.
- Add an uppercase `R` prefix regression case.

Tests
- `git diff --check`
- `npm ci`
- `cd packages/pyright-internal && npm run webpack:testserver` (with a local, uncommitted `docstubs/.placeholder` so the test bundle copy glob has a source in this worktree)
- `cd packages/pyright-internal && node --max-old-space-size=8192 --expose-gc ./node_modules/jest/bin/jest languageServer.test.ts -t onTypeFormatting --runInBand --forceExit`
- `npm run typecheck`
- `npx prettier -c packages/pyright-internal/src/languageServerBase.ts packages/pyright-internal/src/tests/languageServer.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint packages/pyright-internal/src/languageServerBase.ts packages/pyright-internal/src/tests/languageServer.test.ts`

Screenshots/Logs
- N/A

Fixes #1687
