### PR TITLE
docs: clarify reportUnannotatedClassAttribute for instance attributes

### DIFF
--- a/docs/benefits-over-pyright/new-diagnostic-rules.md
+++ b/docs/benefits-over-pyright/new-diagnostic-rules.md
@@ -271,7 +271,39 @@ since pyright does not warn when a class attribute without a type annotation is 
 -   you encountered performance issues with `reportIncompatibleUnannotatedOverride`
 -   you prefer explicit type annotations to reduce the risk of introducing unexpected breaking changes to your API
 
-`reportUnannotatedClassAttribute` will report an error on all unannotated class attributes that can potentially be overridden (ie. not final or private), even if they don't override an attribute on a base class with an incompatible type.
+`reportUnannotatedClassAttribute` will report an error on all unannotated attributes declared on a class that can potentially be overridden (ie. not final or private), even if they don't override an attribute on a base class with an incompatible type.
+
+this includes instance attributes assigned through `self`:
+
+```py
+class Foo:
+    def __init__(self, bar: str) -> None:
+        self.bar = bar  # error: reportUnannotatedClassAttribute
+```
+
+the explicit annotation prevents a subclass from changing the runtime type without a diagnostic from type checkers that don't support `reportIncompatibleUnannotatedOverride`:
+
+```py
+from typing import reveal_type
+
+
+class Foo:
+    def __init__(self, bar: str) -> None:
+        self.bar: str = bar
+
+
+class FooChild(Foo):
+    def __init__(self) -> None:
+        super().__init__("")
+        self.bar = 1  # error: reportIncompatibleUnannotatedOverride
+
+
+def fn(foo: Foo) -> None:
+    reveal_type(foo.bar)  # basedpyright: str, runtime: int
+
+
+fn(FooChild())
+```
 
 ## `reportInvalidAbstractMethod`
 


### PR DESCRIPTION
Summary
- Clarify that reportUnannotatedClassAttribute also applies to instance attributes assigned through self.
- Add the small subclass override example from the linked discussion so the rule's safety goal is easier to understand.

Reproduction
- A user reading the current rule docs can reasonably interpret “class attributes” as excluding assignments like self.bar = bar inside __init__.
- Issue #1599 tracks that confusion and asks to include the example from #1208.

Root cause
- The existing docs describe unannotated class attributes generally, but do not show that instance attributes declared on the class are included.
- The docs also do not show the runtime/type-checker mismatch that reportUnannotatedClassAttribute and reportIncompatibleUnannotatedOverride are meant to prevent.

Changes
- Reword the reportUnannotatedClassAttribute description to cover attributes declared on a class.
- Add an explicit self.bar example.
- Add a minimal Foo/FooChild example showing the unsafe override case and the related diagnostic.

Tests
- ./node_modules/.bin/prettier -c docs/benefits-over-pyright/new-diagnostic-rules.md
- git diff --check
- python3 pw uv sync
- python3 pw uv run mkdocs build --strict

Screenshots/Logs
- Not applicable; documentation-only change.

Closes #1599