### PR TITLE
docs: mention py.typed for missing type stubs

### DIFF
--- a/docs/configuration/config-files.md
+++ b/docs/configuration/config-files.md
@@ -134,7 +134,7 @@ The following settings allow more fine grained control over the **typeCheckingMo
 
 - <a name="reportInvalidTypeForm"></a> **reportInvalidTypeForm** [boolean or string, optional]: Generate or suppress diagnostics for type annotations that use invalid type expression forms or are semantically invalid.
 
-- <a name="reportMissingTypeStubs"></a> **reportMissingTypeStubs** [boolean or string, optional]: Generate or suppress diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis.
+- <a name="reportMissingTypeStubs"></a> **reportMissingTypeStubs** [boolean or string, optional]: Generate or suppress diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). For inline-typed third-party packages, this can also indicate that the package is missing a `py.typed` marker file. The type checker requires stubs or [PEP 561](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information) package metadata to do its best job at analysis.
 
 - <a name="reportImportCycles"></a> **reportImportCycles** [boolean or string, optional]: Generate or suppress diagnostics for cyclical import chains. These are not errors in Python, but they do slow down type analysis and often hint at architectural layering issues. Generally, they should be avoided.
 

--- a/docs/usage/type-stubs.md
+++ b/docs/usage/type-stubs.md
@@ -6,6 +6,8 @@ Type stubs are “.pyi” files that specify the public interface for a library.
 
 Regardless of the search path, Pyright always attempts to resolve an import with a type stub (“.pyi”) file before falling back to a python source (“.py”) file. If a type stub cannot be located for an external import, Pyright will try to use inline type information if the module is part of a package that contains a “py.typed” file (defined in [PEP 561](https://www.python.org/dev/peps/pep-0561/)). If the module is part of a package that doesn’t contain a “py.typed” file, Pyright will treat all of the symbols imported from these modules as having type “Unknown”, and wildcard imports (of the form `from foo import *`) will not populate the module’s namespace with specific symbol names.
 
+If `reportMissingTypeStubs` reports a third-party package that already contains type annotations in its source files, the package may be missing the `py.typed` marker file. Adding that marker is the package maintainer’s way to opt in to PEP 561 inline typing. If you cannot update the package, use a type stub package or a custom stub as described below.
+
 Why does Pyright not attempt (by default) to determine types from imported python sources? There are several reasons.
 
 1. Imported libraries can be quite large, so analyzing them can require significant time and computation.
@@ -60,4 +62,3 @@ _FuncT = TypeVar("_FuncT", bound=Callable[..., Any])
 
 def my_decorator(*args, **kw) -> Callable[[_FuncT], _FuncT]: ...
 ```
-

--- a/docs/usage/type-stubs.md
+++ b/docs/usage/type-stubs.md
@@ -6,7 +6,7 @@ Type stubs are “.pyi” files that specify the public interface for a library.
 
 Regardless of the search path, Pyright always attempts to resolve an import with a type stub (“.pyi”) file before falling back to a python source (“.py”) file. If a type stub cannot be located for an external import, Pyright will try to use inline type information if the module is part of a package that contains a “py.typed” file (defined in [PEP 561](https://www.python.org/dev/peps/pep-0561/)). If the module is part of a package that doesn’t contain a “py.typed” file, Pyright will treat all of the symbols imported from these modules as having type “Unknown”, and wildcard imports (of the form `from foo import *`) will not populate the module’s namespace with specific symbol names.
 
-If `reportMissingTypeStubs` reports a third-party package that already contains type annotations in its source files, the package may be missing the `py.typed` marker file. Adding that marker is the package maintainer’s way to opt in to PEP 561 inline typing. If you cannot update the package, use a type stub package or a custom stub as described below.
+If `reportMissingTypeStubs` reports a third-party package that already contains type annotations in its source files, the package may be missing the `py.typed` marker file. Adding that marker is the package maintainer's way to opt in to PEP 561 inline typing. If you cannot update the package, use a type stub package or a custom stub as described below.
 
 Why does Pyright not attempt (by default) to determine types from imported python sources? There are several reasons.
 

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -342,7 +342,7 @@
                                 "string",
                                 "boolean"
                             ],
-                            "description": "Diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). The type checker requires type stubs to do its best job at analysis.",
+                            "description": "Diagnostics for imports that have no corresponding type stub file (either a typeshed file or a custom type stub). For inline-typed third-party packages, this can also indicate that the package is missing a py.typed marker file.",
                             "default": "none",
                             "enum": [
                                 "none",


### PR DESCRIPTION
Summary
- Document that `reportMissingTypeStubs` can indicate a missing `py.typed` marker for inline-typed third-party packages.
- Add the clarification to the configuration reference, type stub usage docs, and VS Code setting description.

Reproduction
- See #1253: a package may include inline type annotations, but type checkers ignore them for third-party packages unless the distribution opts in with `py.typed` as described by PEP 561.
- The existing `reportMissingTypeStubs` docs only mention missing stub files, which can make this failure mode look like a `.pyi`-only problem.

Root cause
- The docs describe the diagnostic in terms of missing type stubs, but do not point users to the PEP 561 `py.typed` marker that enables inline package typing.

Changes
- Clarified `reportMissingTypeStubs` in `docs/configuration/config-files.md`.
- Added a note to `docs/usage/type-stubs.md` explaining the inline-typed package case.
- Updated the VS Code setting description in `packages/vscode-pyright/package.json`.

Tests
- `node -e "JSON.parse(require('fs').readFileSync('packages/vscode-pyright/package.json','utf8')); console.log('package.json ok')"`
- `git diff --check`
- `npx --yes prettier@2.8.8 -c docs/configuration/config-files.md docs/usage/type-stubs.md packages/vscode-pyright/package.json`

Screenshots/Logs
- Not applicable; documentation/configuration text only.

Part of #1253.
