### PR TITLE
docs: explain importStrategy for debugging

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -33,13 +33,13 @@ To debug pyright, open the root source directory within VS Code. Open the debug 
 
 ### VSCode extension
 
-To debug the VS Code extension, select “Pyright extension” from the debug target menu. Click on the green “run” icon or press F5 to build and launch a second copy of VS Code with the extension. Within the second VS Code instance, open a python source file so the pyright extension is loaded. Return to the first instance of VS Code and select “Pyright extension attach server” from the debug target menu and click the green “run” icon. This will attach the debugger to the process that hosts the type checker. You can now set breakpoints, etc.
+To debug the VS Code extension, select “Pyright extension” from the debug target menu. Click on the green “run” icon or press F5 to build and launch a second copy of VS Code with the extension. Within the second VS Code instance, open a python source file so the pyright extension is loaded. Set `basedpyright.importStrategy` to `"useBundled"` before attaching the node debugger. Return to the first instance of VS Code and select “Pyright extension attach server” from the debug target menu and click the green “run” icon. This will attach the debugger to the process that hosts the type checker. You can now set breakpoints, etc.
 
 To debug the VS Code extension in watch mode, you can do the above, but select “Pyright extension (watch mode)”. When pyright's source is saved, an incremental build will occur, and you can either reload the second VS Code window or relaunch it to start using the updated code. Note that the watcher stays open when debugging stops, so you may need to stop it (or close VS Code) if you want to perform packaging steps without the output potentially being overwritten.
 
 !!! tip "inspecting LSP messages"
 
-    while the VSCode extension is running in this mode, you can run the `npm: lsp-inspect` task to launch the [LSP inspector](https://lsp-devtools.readthedocs.io/en/latest/lsp-devtools/guide/inspect-command.html), which allows you to browse all messages sent between the client and server:
+    while the VSCode extension is running in this mode, set `basedpyright.importStrategy` to `"fromEnvironment"` and run the `npm: lsp-inspect` task to launch the [LSP inspector](https://lsp-devtools.readthedocs.io/en/latest/lsp-devtools/guide/inspect-command.html), which allows you to browse all messages sent between the client and server:
 
     ![](./lspinspector.svg)
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -33,13 +33,20 @@ To debug pyright, open the root source directory within VS Code. Open the debug 
 
 ### VSCode extension
 
-To debug the VS Code extension, select “Pyright extension” from the debug target menu. Click on the green “run” icon or press F5 to build and launch a second copy of VS Code with the extension. Within the second VS Code instance, open a python source file so the pyright extension is loaded. Set `basedpyright.importStrategy` to `"useBundled"` before attaching the node debugger. Return to the first instance of VS Code and select “Pyright extension attach server” from the debug target menu and click the green “run” icon. This will attach the debugger to the process that hosts the type checker. You can now set breakpoints, etc.
+To debug the VS Code extension:
+
+1. Set `basedpyright.importStrategy` to `"useBundled"` in the project you plan to open in the second VS Code instance.
+2. Select “Pyright extension” from the debug target menu.
+3. Click on the green “run” icon or press F5 to build and launch a second copy of VS Code with the extension.
+4. Within the second VS Code instance, open a python source file so the pyright extension is loaded.
+5. Return to the first instance of VS Code and select “Pyright extension attach server” from the debug target menu.
+6. Click the green “run” icon to attach the debugger to the process that hosts the type checker.
 
 To debug the VS Code extension in watch mode, you can do the above, but select “Pyright extension (watch mode)”. When pyright's source is saved, an incremental build will occur, and you can either reload the second VS Code window or relaunch it to start using the updated code. Note that the watcher stays open when debugging stops, so you may need to stop it (or close VS Code) if you want to perform packaging steps without the output potentially being overwritten.
 
 !!! tip "inspecting LSP messages"
 
-    while the VSCode extension is running in this mode, set `basedpyright.importStrategy` to `"fromEnvironment"` and run the `npm: lsp-inspect` task to launch the [LSP inspector](https://lsp-devtools.readthedocs.io/en/latest/lsp-devtools/guide/inspect-command.html), which allows you to browse all messages sent between the client and server:
+    Before launching the extension debug config, set `basedpyright.importStrategy` to `"fromEnvironment"` in the project you plan to open. While the VSCode extension is running in this mode, run the `npm: lsp-inspect` task to launch the [LSP inspector](https://lsp-devtools.readthedocs.io/en/latest/lsp-devtools/guide/inspect-command.html), which allows you to browse all messages sent between the client and server:
 
     ![](./lspinspector.svg)
 


### PR DESCRIPTION
Summary
- Document the `basedpyright.importStrategy` values required by the VS Code debugging workflows in the contributing guide.
- Fixes #1600.

Reproduction
- Issue #1600 points out that the contributing docs do not mention the required `importStrategy` values for attaching the node debugger or using `lsp-inspector`.

Root cause
- The debugging instructions describe the launch configs and LSP inspector task, but not which language server source the extension must use for each workflow.

Changes
- Mention `"useBundled"` before attaching the node debugger.
- Mention `"fromEnvironment"` before running the `npm: lsp-inspect` task.

Tests
- `git diff --check origin/main..HEAD`
- `npx --yes prettier@2.8.8 -c docs/development/contributing.md`

Screenshots/Logs
- Not applicable; docs-only change.

This PR follows the repository AI policy.