### PR TITLE
docs: clarify unannotated class attribute rule

### DIFF
--- a/docs/benefits-over-pyright/new-diagnostic-rules.md
+++ b/docs/benefits-over-pyright/new-diagnostic-rules.md
@@ -273,6 +273,30 @@ since pyright does not warn when a class attribute without a type annotation is 
 
 `reportUnannotatedClassAttribute` will report an error on all unannotated class attributes that can potentially be overridden (ie. not final or private), even if they don't override an attribute on a base class with an incompatible type.
 
+this also includes instance attributes assigned through `self`, because they can be overridden by subclasses with an incompatible type:
+
+```py
+from typing import reveal_type
+
+
+class Foo:
+    def __init__(self, bar: str) -> None:
+        self.bar = bar  # error: `bar` needs a type annotation
+
+
+class FooChild(Foo):
+    def __init__(self) -> None:
+        super().__init__("")
+        self.bar = 1  # no error unless `reportIncompatibleUnannotatedOverride` is enabled
+
+
+def fn(foo: Foo) -> None:
+    reveal_type(foo.bar)  # basedpyright: str, runtime: int
+
+
+fn(FooChild())
+```
+
 ## `reportInvalidAbstractMethod`
 
 pyright ignores methods decorated with `@abstractmethod` if the class is not abstract:


### PR DESCRIPTION
Summary
- Clarifies that `reportUnannotatedClassAttribute` also applies to instance attributes assigned through `self`.
- Adds a concrete subclass override example showing why an unannotated instance attribute can be unsafe.
- Fixes #1599.

Reproduction
- Read the `reportUnannotatedClassAttribute` docs and compare them with the example discussed in #1208.
- The rule name and existing text mention class attributes, but the diagnostic can also be reported for `self` attributes assigned in `__init__`.

Root cause
- The docs did not show the instance-attribute case that motivated #1599, so readers could not easily connect the diagnostic to unsafe subclass overrides.

Changes
- Added a short explanation that `self` attributes are included because subclasses can override them with incompatible types.
- Added the reduced example from the maintainer discussion showing the static type/runtime type mismatch.

Tests
- `git diff --check upstream/main..HEAD`
- `npx --yes prettier@2.8.8 -c docs/benefits-over-pyright/new-diagnostic-rules.md`

Screenshots/Logs
- Not applicable; documentation-only change.

This PR follows the repository AI policy.