### PR TITLE
feat: Add syntax-aware Python selection ranges

### DIFF
--- a/packages/pyright-internal/src/languageServerBase.ts
+++ b/packages/pyright-internal/src/languageServerBase.ts
@@ -63,6 +63,8 @@ import {
     RenameFilesParams,
     RenameParams,
     ResultProgressReporter,
+    SelectionRange,
+    SelectionRangeParams,
     SignatureHelp,
     SignatureHelpParams,
     SymbolInformation,
@@ -148,6 +150,7 @@ import { canNavigateToFile } from './languageService/navigationUtils';
 import { ReferencesProvider } from './languageService/referencesProvider';
 import { ImplementationProvider } from './languageService/implementationProvider';
 import { RenameProvider } from './languageService/renameProvider';
+import { SelectionRangeProvider } from './languageService/selectionRangeProvider';
 import { SignatureHelpProvider } from './languageService/signatureHelpProvider';
 import { WorkspaceSymbolProvider } from './languageService/workspaceSymbolProvider';
 import { Localizer, setLocaleOverride } from './localization/localize';
@@ -620,6 +623,8 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         this.connection.onDocumentHighlight(async (params, token) => this.onDocumentHighlight(params, token));
 
+        this.connection.onSelectionRanges(async (params, token) => this.onSelectionRanges(params, token));
+
         this.connection.onSignatureHelp(async (params, token) => this.onSignatureHelp(params, token));
 
         this.connection.onCompletion((params, token) => this.onCompletion(params, token));
@@ -758,6 +763,7 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
                 workspaceSymbolProvider: { workDoneProgress: true },
                 hoverProvider: { workDoneProgress: true },
                 documentHighlightProvider: { workDoneProgress: true },
+                selectionRangeProvider: true,
                 renameProvider: { prepareProvider: true, workDoneProgress: true },
                 completionProvider: {
                     triggerCharacters: this.client.hasVisualStudioExtensionsCapability
@@ -1076,6 +1082,21 @@ export abstract class LanguageServerBase implements LanguageServerInterface, Dis
 
         return workspace.service.run((program) => {
             return new DocumentHighlightProvider(program, uri, params.position, token).getDocumentHighlight();
+        }, token);
+    }
+
+    protected async onSelectionRanges(
+        params: SelectionRangeParams,
+        token: CancellationToken
+    ): Promise<SelectionRange[] | null | undefined> {
+        const uri = this.convertLspUriStringToUri(params.textDocument.uri);
+        const workspace = await this.getWorkspaceForFile(uri);
+        if (workspace.disableLanguageServices) {
+            return undefined;
+        }
+
+        return workspace.service.run((program) => {
+            return new SelectionRangeProvider(program, uri, params.positions, token).getSelectionRanges();
         }, token);
     }
 

--- a/packages/pyright-internal/src/languageService/selectionRangeProvider.ts
+++ b/packages/pyright-internal/src/languageService/selectionRangeProvider.ts
@@ -1,0 +1,85 @@
+/*
+ * selectionRangeProvider.ts
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * Provides syntax-aware selection ranges for a Python document.
+ */
+
+import { CancellationToken, SelectionRange } from 'vscode-languageserver';
+
+import { findNodeByOffset, getAncestorsIncludingSelf } from '../analyzer/parseTreeUtils';
+import { throwIfCancellationRequested } from '../common/cancellationUtils';
+import { ProgramView } from '../common/extensibility';
+import { convertPositionToOffset, convertTextRangeToRange } from '../common/positionUtils';
+import { Position, TextRange } from '../common/textRange';
+import { Uri } from '../common/uri/uri';
+import { improveNodeByOffset, nodeRange } from '../parser/parseNodeUtils';
+
+export class SelectionRangeProvider {
+    constructor(
+        private readonly _program: ProgramView,
+        private readonly _fileUri: Uri,
+        private readonly _positions: Position[],
+        private readonly _token: CancellationToken
+    ) {}
+
+    getSelectionRanges(): SelectionRange[] | undefined {
+        throwIfCancellationRequested(this._token);
+
+        const parseResults = this._program.getParseResults(this._fileUri);
+        if (!parseResults) {
+            return undefined;
+        }
+
+        const parseTree = parseResults.parserOutput.parseTree;
+        const lines = parseResults.tokenizerOutput.lines;
+        const results: SelectionRange[] = [];
+
+        for (const position of this._positions) {
+            throwIfCancellationRequested(this._token);
+
+            const offset = convertPositionToOffset(position, lines);
+            if (offset === undefined) {
+                return undefined;
+            }
+
+            const node = findNodeByOffset(parseTree, offset);
+            if (!node) {
+                return undefined;
+            }
+
+            const ranges: TextRange[] = [];
+            for (const ancestor of getAncestorsIncludingSelf(improveNodeByOffset(node, offset))) {
+                const range = nodeRange(ancestor);
+                const previousRange = ranges[ranges.length - 1];
+                if (
+                    range.length === 0 ||
+                    (previousRange &&
+                        (!TextRange.containsRange(range, previousRange) ||
+                            (range.start === previousRange.start && range.length === previousRange.length)))
+                ) {
+                    continue;
+                }
+
+                ranges.push(range);
+            }
+
+            let selectionRange: SelectionRange | undefined;
+            for (let i = ranges.length - 1; i >= 0; i--) {
+                selectionRange = {
+                    range: convertTextRangeToRange(ranges[i], lines),
+                    parent: selectionRange,
+                };
+            }
+
+            if (!selectionRange) {
+                return undefined;
+            }
+
+            results.push(selectionRange);
+        }
+
+        return results;
+    }
+}

--- a/packages/pyright-internal/src/tests/selectionRangeProvider.test.ts
+++ b/packages/pyright-internal/src/tests/selectionRangeProvider.test.ts
@@ -1,0 +1,101 @@
+/*
+ * selectionRangeProvider.test.ts
+ *
+ * Tests for syntax-aware selection ranges.
+ */
+
+import assert from 'assert';
+import { CancellationToken, SelectionRange } from 'vscode-languageserver';
+
+import { convertOffsetToPosition } from '../common/positionUtils';
+import { rangesAreEqual } from '../common/textRange';
+import { SelectionRangeProvider } from '../languageService/selectionRangeProvider';
+import { parseAndGetTestState } from './harness/fourslash/testState';
+
+test('includes enclosing function and class ranges', () => {
+    const code = `
+//// class Pricing:
+////     async def create_default_pricing_tables():/*header*/
+////         value = 1
+////         return /*body*/value
+////
+//// outside = 2
+    `;
+    const state = parseAndGetTestState(code).state;
+
+    for (const markerName of ['header', 'body']) {
+        const marker = state.getMarkerByName(markerName);
+        state.openFile(marker.fileName);
+        const lines = state.program.getParseResults(marker.fileUri)!.tokenizerOutput.lines;
+
+        const result = new SelectionRangeProvider(
+            state.program,
+            marker.fileUri,
+            [convertOffsetToPosition(marker.position, lines)],
+            CancellationToken.None
+        ).getSelectionRanges();
+
+        assert(result);
+        const ranges = flattenRanges(result[0]);
+        assert(
+            ranges.some(
+                (range) =>
+                    range.start.line === 1 &&
+                    range.start.character === 4 &&
+                    range.end.line === 3 &&
+                    range.end.character === 20
+            ),
+            'Expected the method range'
+        );
+        assert(
+            ranges.some(
+                (range) =>
+                    range.start.line === 0 &&
+                    range.start.character === 0 &&
+                    range.end.line === 3 &&
+                    range.end.character === 20
+            ),
+            'Expected the class range'
+        );
+        assert(
+            ranges.some((range) => range.start.line === 0 && range.start.character === 0 && range.end.line === 5),
+            'Expected the module range'
+        );
+    }
+});
+
+test('returns one hierarchy for each requested position', () => {
+    const code = `
+//// def first():/*first*/
+////     pass
+////
+//// def second():/*second*/
+////     pass
+    `;
+    const state = parseAndGetTestState(code).state;
+    const first = state.getMarkerByName('first');
+    const second = state.getMarkerByName('second');
+    state.openFile(first.fileName);
+    const lines = state.program.getParseResults(first.fileUri)!.tokenizerOutput.lines;
+
+    const result = new SelectionRangeProvider(
+        state.program,
+        first.fileUri,
+        [convertOffsetToPosition(first.position, lines), convertOffsetToPosition(second.position, lines)],
+        CancellationToken.None
+    ).getSelectionRanges();
+
+    assert(result);
+    assert.strictEqual(result.length, 2);
+    assert(!rangesAreEqual(result[0].range, result[1].range));
+});
+
+function flattenRanges(selectionRange: SelectionRange) {
+    const ranges = [];
+    let current: SelectionRange | undefined = selectionRange;
+    while (current) {
+        ranges.push(current.range);
+        current = current.parent;
+    }
+    return ranges;
+}


### PR DESCRIPTION
### Overview

- Implement `textDocument/selectionRange` from the Python parse tree, fixing #1170.
- Include enclosing function and class scopes from declaration headers and bodies.
- _Written by GPT-5.6 Sol, using Cursor._

### Testing

Type-checks pass for changed TypeScript roots; tests not run per request.
