### PR TITLE
Support new Python Environments API when enabled

### DIFF
--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -2017,6 +2017,7 @@
         "webpack-dev": "npm run clean && rspack build -c rspack.config.js --mode development --watch"
     },
     "dependencies": {
+        "@vscode/python-environments": "^1.0.0",
         "@vscode/python-extension": "^1.0.5",
         "vscode-jsonrpc": "^9.0.0-next.8",
         "vscode-languageclient": "^10.0.0-next.16",
@@ -2029,7 +2030,6 @@
         "@rspack/core": "^2.0.5",
         "@types/node": "^25.9.2",
         "@types/vscode": "^1.101.0",
-        "@vscode/python-environments": "^1.0.0",
         "@vscode/vsce": "^3.9.2",
         "chalk": "^4.1.2",
         "esbuild-loader": "^4.5.0",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -2029,6 +2029,7 @@
         "@rspack/core": "^2.0.5",
         "@types/node": "^25.9.2",
         "@types/vscode": "^1.101.0",
+        "@vscode/python-environments": "^1.0.0",
         "@vscode/vsce": "^3.9.2",
         "chalk": "^4.1.2",
         "esbuild-loader": "^4.5.0",

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -53,6 +53,108 @@ let languageClient: LanguageClient | undefined;
 
 const pythonPathChangedListenerMap = new Map<string, string>();
 
+// Hand-written subset of the ms-python.vscode-python-envs API (no npm types exist).
+// https://github.com/microsoft/vscode-python-environments/blob/main/src/api.ts
+interface PythonEnvironmentExecutionInfo {
+    readonly run: { readonly executable: string };
+}
+interface PythonEnvironment {
+    readonly envId: { readonly id: string; readonly managerId: string };
+    readonly environmentPath: Uri;
+    readonly execInfo?: PythonEnvironmentExecutionInfo;
+}
+interface DidChangeEnvironmentEventArgs {
+    readonly uri: Uri | undefined;
+}
+interface PythonEnvsApi {
+    getEnvironment(scope: Uri | undefined): Promise<PythonEnvironment | undefined>;
+    readonly onDidChangeEnvironment?: (listener: (e: DidChangeEnvironmentEventArgs) => void) => { dispose(): void };
+}
+
+/**
+ * Check whether the user has opted into the new Python Environments
+ * extension (`ms-python.vscode-python-envs`).
+ */
+function useEnvsExtension(): boolean {
+    return workspace.getConfiguration('python').get<boolean>('useEnvironmentsExtension', false);
+}
+
+/**
+ * Try to acquire the python-envs API.  Returns `undefined` when the
+ * extension is not installed or the setting is off.
+ */
+async function getEnvsApi(log: (message: string) => void): Promise<PythonEnvsApi | undefined> {
+    if (!useEnvsExtension()) {
+        return undefined;
+    }
+    const ext = extensions.getExtension('ms-python.vscode-python-envs');
+    if (!ext) {
+        log(
+            'python.useEnvironmentsExtension is true but ms-python.vscode-python-envs is not installed; using classic API'
+        );
+        return undefined;
+    }
+    try {
+        const api = ext.isActive ? ext.exports : await ext.activate();
+        return api as PythonEnvsApi;
+    } catch (error) {
+        log(`Exception occurred when activating ms-python.vscode-python-envs: ${JSON.stringify(error)}`);
+        return undefined;
+    }
+}
+
+/**
+ * Resolve the python executable path for the given scope (a workspace folder, or
+ * undefined for the active/global interpreter) from the new python-envs API.
+ * Prefers `execInfo.run.executable`, falling back to the environment path.
+ * Returns `undefined` on miss/throw so callers can fall back to the classic API.
+ */
+async function getPythonPathFromEnvsApi(
+    envsApi: PythonEnvsApi,
+    log: (message: string) => void,
+    scopeUri: Uri | undefined,
+    postConfigChanged: () => void
+): Promise<string | undefined> {
+    try {
+        installEnvsChangedListener(envsApi, scopeUri, postConfigChanged);
+        const env = await envsApi.getEnvironment(scopeUri);
+        if (!env) {
+            log('No pythonPath provided by Python Environments extension');
+            return undefined;
+        }
+        const result = env.execInfo?.run.executable ?? env.environmentPath.fsPath;
+        log(`Received pythonPath from Python Environments extension: ${result}`);
+        return result;
+    } catch (error) {
+        log(
+            `Exception occurred when attempting to read pythonPath from Python Environments extension: ${JSON.stringify(
+                error
+            )}`
+        );
+        return undefined;
+    }
+}
+
+/**
+ * Subscribe to python-envs interpreter changes for a scope and trigger a config
+ * refresh, mirroring the classic `installPythonPathChangedListener`. Reuses
+ * `pythonPathChangedListenerMap` so we install at most one listener per scope
+ * across both APIs (only one API resolves the path for a given scope).
+ */
+function installEnvsChangedListener(envsApi: PythonEnvsApi, scopeUri: Uri | undefined, postConfigChanged: () => void) {
+    if (!envsApi.onDidChangeEnvironment) {
+        return;
+    }
+    const uriString = scopeUri ? scopeUri.toString() : '';
+    if (pythonPathChangedListenerMap.has(uriString)) {
+        return;
+    }
+    envsApi.onDidChangeEnvironment(() => {
+        postConfigChanged();
+    });
+    pythonPathChangedListenerMap.set(uriString, uriString);
+}
+
 // Request a heap size of 3GB. This is reasonable for modern systems.
 const defaultHeapSize = 3072;
 
@@ -117,10 +219,29 @@ export async function activate(context: ExtensionContext) {
     let serverOptions: ServerOptions | undefined = undefined;
     const bundlePath = context.asAbsolutePath(path.join('dist', 'server.js'));
     if (workspace.getConfiguration('basedpyright').get('importStrategy') === 'fromEnvironment') {
-        const pythonApi = await PythonExtension.api();
         const isWindows = os.platform() === 'win32';
         const executableName = `basedpyright-langserver${isWindows ? '.exe' : ''}`;
-        const executableDir = path.join(pythonApi.environments.getActiveEnvironmentPath().path, '..');
+
+        // When the new Python Environments API is active, resolve the environment
+        // from it (matching what Pylance reads), otherwise use the classic API.
+        let interpreterPath: string | undefined;
+        const envsApi = await getEnvsApi((message) => console.log(message));
+        if (envsApi) {
+            try {
+                const env = await envsApi.getEnvironment(undefined);
+                interpreterPath = env?.execInfo?.run.executable ?? env?.environmentPath.fsPath;
+            } catch (error) {
+                console.warn(
+                    `failed to read active environment from Python Environments extension: ${JSON.stringify(error)}`
+                );
+            }
+        }
+        if (interpreterPath === undefined) {
+            const pythonApi = await PythonExtension.api();
+            interpreterPath = pythonApi.environments.getActiveEnvironmentPath().path;
+        }
+        const executableDir = path.join(interpreterPath, '..');
+
         const originalExecutablePath = path.join(executableDir, executableName);
         if (existsSync(originalExecutablePath)) {
             console.log('using pyright executable:', originalExecutablePath);
@@ -406,6 +527,18 @@ async function getPythonPathFromPythonExtension(
     scopeUri: Uri | undefined,
     postConfigChanged: () => void
 ): Promise<string | undefined> {
+    // When python.useEnvironmentsExtension is on, the interpreter is managed by
+    // ms-python.vscode-python-envs (what Pylance reads), otherwise use the classic API.
+    const log = (message: string) => outputChannel.appendLine(message);
+    const envsApi = await getEnvsApi(log);
+    if (envsApi) {
+        const result = await getPythonPathFromEnvsApi(envsApi, log, scopeUri, postConfigChanged);
+        if (result !== undefined) {
+            return result;
+        }
+        log('Python Environments extension returned no interpreter, use classic API');
+    }
+
     try {
         const extension = extensions.getExtension('ms-python.python');
         if (!extension) {

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -10,7 +10,7 @@
  */
 
 import { PythonExtension } from '@vscode/python-extension';
-import { EXTENSION_ID as pythonEnvsExtensionId, type PythonEnvironmentApi } from '@vscode/python-environments';
+import { PythonEnvironments, type PythonEnvironmentApi } from '@vscode/python-environments';
 import { existsSync } from 'fs';
 import os from 'os';
 import * as path from 'path';
@@ -70,16 +70,10 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnviron
     if (!useEnvsExtension()) {
         return undefined;
     }
-    const ext = extensions.getExtension(pythonEnvsExtensionId);
-    if (!ext) {
-        log(`python.useEnvironmentsExtension is true but ${pythonEnvsExtensionId} is not installed; using classic API`);
-        return undefined;
-    }
     try {
-        const api = ext.isActive ? ext.exports : await ext.activate();
-        return api as PythonEnvironmentApi;
+        return await PythonEnvironments.api();
     } catch (error) {
-        log(`Exception occurred when activating ${pythonEnvsExtensionId}: ${JSON.stringify(error)}`);
+        log(`Exception occurred when activating Python Environments extension: ${JSON.stringify(error)}`);
         return undefined;
     }
 }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -97,7 +97,7 @@ async function getPythonPathFromEnvsApi(
     postConfigChanged: () => void
 ): Promise<string | undefined> {
     try {
-        installEnvsChangedListener(envsApi, scopeUri, postConfigChanged);
+        installPythonPathChangedListener(envsApi.onDidChangeEnvironment, scopeUri, postConfigChanged);
         const env = await envsApi.getEnvironment(scopeUri);
         if (!env) {
             log('No pythonPath provided by Python Environments extension');
@@ -114,30 +114,6 @@ async function getPythonPathFromEnvsApi(
         );
         return undefined;
     }
-}
-
-/**
- * Subscribe to python-envs interpreter changes for a scope and trigger a config
- * refresh, mirroring the classic `installPythonPathChangedListener`. Reuses
- * `pythonPathChangedListenerMap` so we install at most one listener per scope
- * across both APIs (only one API resolves the path for a given scope).
- */
-function installEnvsChangedListener(
-    envsApi: PythonEnvironmentApi,
-    scopeUri: Uri | undefined,
-    postConfigChanged: () => void
-) {
-    if (!envsApi.onDidChangeEnvironment) {
-        return;
-    }
-    const uriString = scopeUri ? scopeUri.toString() : '';
-    if (pythonPathChangedListenerMap.has(uriString)) {
-        return;
-    }
-    envsApi.onDidChangeEnvironment(() => {
-        postConfigChanged();
-    });
-    pythonPathChangedListenerMap.set(uriString, uriString);
 }
 
 // Request a heap size of 3GB. This is reasonable for modern systems.
@@ -217,7 +193,9 @@ export async function activate(context: ExtensionContext) {
                 interpreterPath = env?.execInfo?.run.executable ?? env?.environmentPath.fsPath;
             } catch (error) {
                 console.warn(
-                    `failed to read active environment from Python Environments extension, falling back to the old API: ${JSON.stringify(error)}`
+                    `failed to read active environment from Python Environments extension, falling back to the old API: ${JSON.stringify(
+                        error
+                    )}`
                 );
             }
         }
@@ -569,10 +547,14 @@ async function getPythonPathFromPythonExtension(
 }
 
 function installPythonPathChangedListener(
-    onDidChangeExecutionDetails: (callback: () => void) => void,
+    onDidChangeExecutionDetails: ((callback: () => void) => void) | undefined,
     scopeUri: Uri | undefined,
     postConfigChanged: () => void
 ) {
+    if (!onDidChangeExecutionDetails) {
+        return;
+    }
+
     const uriString = scopeUri ? scopeUri.toString() : '';
 
     // No need to install another listener for this URI if

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -73,7 +73,8 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnviron
     try {
         return await PythonEnvironments.api();
     } catch (error) {
-        log(`Exception occurred when activating Python Environments extension: ${JSON.stringify(error)}`);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log(`Exception occurred when activating Python Environments extension: ${errorMessage}`);
         return undefined;
     }
 }
@@ -98,11 +99,8 @@ async function getPythonPathFromEnvsApi(
         log(`Received pythonPath from Python Environments extension: ${result}`);
         return result;
     } catch (error) {
-        log(
-            `Exception occurred when attempting to read pythonPath from Python Environments extension: ${JSON.stringify(
-                error
-            )}`
-        );
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log(`Exception occurred when attempting to read pythonPath from Python Environments extension: ${errorMessage}`);
         return undefined;
     }
 }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -100,7 +100,9 @@ async function getPythonPathFromEnvsApi(
         return result;
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        log(`Exception occurred when attempting to read pythonPath from Python Environments extension: ${errorMessage}`);
+        log(
+            `Exception occurred when attempting to read pythonPath from Python Environments extension: ${errorMessage}`
+        );
         return undefined;
     }
 }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -217,7 +217,7 @@ export async function activate(context: ExtensionContext) {
                 interpreterPath = env?.execInfo?.run.executable ?? env?.environmentPath.fsPath;
             } catch (error) {
                 console.warn(
-                    `failed to read active environment from Python Environments extension: ${JSON.stringify(error)}`
+                    `failed to read active environment from Python Environments extension, falling back to the old API: ${JSON.stringify(error)}`
                 );
             }
         }
@@ -521,7 +521,7 @@ async function getPythonPathFromPythonExtension(
         if (result !== undefined) {
             return result;
         }
-        log('Python Environments extension returned no interpreter, use classic API');
+        log('Python Environments extension returned no interpreter, using classic API');
     }
 
     try {

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -10,6 +10,7 @@
  */
 
 import { PythonExtension } from '@vscode/python-extension';
+import type { PythonEnvironmentApi } from '@vscode/python-environments';
 import { existsSync } from 'fs';
 import os from 'os';
 import * as path from 'path';
@@ -53,24 +54,6 @@ let languageClient: LanguageClient | undefined;
 
 const pythonPathChangedListenerMap = new Map<string, string>();
 
-// Hand-written subset of the ms-python.vscode-python-envs API (no npm types exist).
-// https://github.com/microsoft/vscode-python-environments/blob/main/src/api.ts
-interface PythonEnvironmentExecutionInfo {
-    readonly run: { readonly executable: string };
-}
-interface PythonEnvironment {
-    readonly envId: { readonly id: string; readonly managerId: string };
-    readonly environmentPath: Uri;
-    readonly execInfo?: PythonEnvironmentExecutionInfo;
-}
-interface DidChangeEnvironmentEventArgs {
-    readonly uri: Uri | undefined;
-}
-interface PythonEnvsApi {
-    getEnvironment(scope: Uri | undefined): Promise<PythonEnvironment | undefined>;
-    readonly onDidChangeEnvironment?: (listener: (e: DidChangeEnvironmentEventArgs) => void) => { dispose(): void };
-}
-
 /**
  * Check whether the user has opted into the new Python Environments
  * extension (`ms-python.vscode-python-envs`).
@@ -83,7 +66,7 @@ function useEnvsExtension(): boolean {
  * Try to acquire the python-envs API.  Returns `undefined` when the
  * extension is not installed or the setting is off.
  */
-async function getEnvsApi(log: (message: string) => void): Promise<PythonEnvsApi | undefined> {
+async function getEnvsApi(log: (message: string) => void): Promise<PythonEnvironmentApi | undefined> {
     if (!useEnvsExtension()) {
         return undefined;
     }
@@ -96,7 +79,7 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnvsApi
     }
     try {
         const api = ext.isActive ? ext.exports : await ext.activate();
-        return api as PythonEnvsApi;
+        return api as PythonEnvironmentApi;
     } catch (error) {
         log(`Exception occurred when activating ms-python.vscode-python-envs: ${JSON.stringify(error)}`);
         return undefined;
@@ -110,7 +93,7 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnvsApi
  * Returns `undefined` on miss/throw so callers can fall back to the classic API.
  */
 async function getPythonPathFromEnvsApi(
-    envsApi: PythonEnvsApi,
+    envsApi: PythonEnvironmentApi,
     log: (message: string) => void,
     scopeUri: Uri | undefined,
     postConfigChanged: () => void
@@ -141,7 +124,11 @@ async function getPythonPathFromEnvsApi(
  * `pythonPathChangedListenerMap` so we install at most one listener per scope
  * across both APIs (only one API resolves the path for a given scope).
  */
-function installEnvsChangedListener(envsApi: PythonEnvsApi, scopeUri: Uri | undefined, postConfigChanged: () => void) {
+function installEnvsChangedListener(
+    envsApi: PythonEnvironmentApi,
+    scopeUri: Uri | undefined,
+    postConfigChanged: () => void
+) {
     if (!envsApi.onDidChangeEnvironment) {
         return;
     }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -10,7 +10,7 @@
  */
 
 import { PythonExtension } from '@vscode/python-extension';
-import type { PythonEnvironmentApi } from '@vscode/python-environments';
+import { EXTENSION_ID as pythonEnvsExtensionId, type PythonEnvironmentApi } from '@vscode/python-environments';
 import { existsSync } from 'fs';
 import os from 'os';
 import * as path from 'path';
@@ -70,18 +70,16 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnviron
     if (!useEnvsExtension()) {
         return undefined;
     }
-    const ext = extensions.getExtension('ms-python.vscode-python-envs');
+    const ext = extensions.getExtension(pythonEnvsExtensionId);
     if (!ext) {
-        log(
-            'python.useEnvironmentsExtension is true but ms-python.vscode-python-envs is not installed; using classic API'
-        );
+        log(`python.useEnvironmentsExtension is true but ${pythonEnvsExtensionId} is not installed; using classic API`);
         return undefined;
     }
     try {
         const api = ext.isActive ? ext.exports : await ext.activate();
         return api as PythonEnvironmentApi;
     } catch (error) {
-        log(`Exception occurred when activating ms-python.vscode-python-envs: ${JSON.stringify(error)}`);
+        log(`Exception occurred when activating ${pythonEnvsExtensionId}: ${JSON.stringify(error)}`);
         return undefined;
     }
 }

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -81,23 +81,20 @@ async function getEnvsApi(log: (message: string) => void): Promise<PythonEnviron
 /**
  * Resolve the python executable path for the given scope (a workspace folder, or
  * undefined for the active/global interpreter) from the new python-envs API.
- * Prefers `execInfo.run.executable`, falling back to the environment path.
  * Returns `undefined` on miss/throw so callers can fall back to the classic API.
  */
 async function getPythonPathFromEnvsApi(
     envsApi: PythonEnvironmentApi,
     log: (message: string) => void,
-    scopeUri: Uri | undefined,
-    postConfigChanged: () => void
+    scopeUri: Uri | undefined
 ): Promise<string | undefined> {
     try {
-        installPythonPathChangedListener(envsApi.onDidChangeEnvironment, scopeUri, postConfigChanged);
         const env = await envsApi.getEnvironment(scopeUri);
         if (!env) {
             log('No pythonPath provided by Python Environments extension');
             return undefined;
         }
-        const result = env.execInfo?.run.executable ?? env.environmentPath.fsPath;
+        const result = env.execInfo.run.executable;
         log(`Received pythonPath from Python Environments extension: ${result}`);
         return result;
     } catch (error) {
@@ -182,16 +179,7 @@ export async function activate(context: ExtensionContext) {
         let interpreterPath: string | undefined;
         const envsApi = await getEnvsApi((message) => console.log(message));
         if (envsApi) {
-            try {
-                const env = await envsApi.getEnvironment(undefined);
-                interpreterPath = env?.execInfo?.run.executable ?? env?.environmentPath.fsPath;
-            } catch (error) {
-                console.warn(
-                    `failed to read active environment from Python Environments extension, falling back to the old API: ${JSON.stringify(
-                        error
-                    )}`
-                );
-            }
+            interpreterPath = await getPythonPathFromEnvsApi(envsApi, console.log, undefined);
         }
         if (interpreterPath === undefined) {
             const pythonApi = await PythonExtension.api();
@@ -489,7 +477,8 @@ async function getPythonPathFromPythonExtension(
     const log = (message: string) => outputChannel.appendLine(message);
     const envsApi = await getEnvsApi(log);
     if (envsApi) {
-        const result = await getPythonPathFromEnvsApi(envsApi, log, scopeUri, postConfigChanged);
+        installPythonPathChangedListener(envsApi.onDidChangeEnvironment, scopeUri, postConfigChanged);
+        const result = await getPythonPathFromEnvsApi(envsApi, log, scopeUri);
         if (result !== undefined) {
             return result;
         }
@@ -541,14 +530,10 @@ async function getPythonPathFromPythonExtension(
 }
 
 function installPythonPathChangedListener(
-    onDidChangeExecutionDetails: ((callback: () => void) => void) | undefined,
+    onDidChangeExecutionDetails: (callback: () => void) => void,
     scopeUri: Uri | undefined,
     postConfigChanged: () => void
 ) {
-    if (!onDidChangeExecutionDetails) {
-        return;
-    }
-
     const uriString = scopeUri ? scopeUri.toString() : '';
 
     // No need to install another listener for this URI if

--- a/packages/vscode-pyright/src/extension.ts
+++ b/packages/vscode-pyright/src/extension.ts
@@ -179,7 +179,8 @@ export async function activate(context: ExtensionContext) {
         let interpreterPath: string | undefined;
         const envsApi = await getEnvsApi((message) => console.log(message));
         if (envsApi) {
-            interpreterPath = await getPythonPathFromEnvsApi(envsApi, console.log, undefined);
+            // TODO: support multi-root workspaces: https://github.com/DetachHead/basedpyright/issues/991
+            interpreterPath = await getPythonPathFromEnvsApi(envsApi, console.log, workspace.workspaceFolders?.[0].uri);
         }
         if (interpreterPath === undefined) {
             const pythonApi = await PythonExtension.api();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@types/vscode':
         specifier: ^1.101.0
         version: 1.125.0
+      '@vscode/python-environments':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2
@@ -1405,6 +1408,10 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vscode/python-environments@1.0.0':
+    resolution: {integrity: sha512-utsAkb9lX8jVJxTR11aFu5Z2LWNwmHp3Ki+tmNNTiHVY71gNcwgYRrnwRhdE6+DFj3sLznjvcE/dCaAgXX9ohA==}
+    engines: {node: '>=22.21.1', vscode: ^1.110.0}
 
   '@vscode/python-extension@1.0.6':
     resolution: {integrity: sha512-q7KYf+mymM67G0yS6xfhczFwu2teBi5oXHVdNgtCsYhErdSOkwMPtE291SqQahrjTcgKxn7O56i1qb1EQR6o4w==}
@@ -5340,6 +5347,8 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vscode/python-environments@1.0.0': {}
 
   '@vscode/python-extension@1.0.6': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
 
   packages/vscode-pyright:
     dependencies:
+      '@vscode/python-environments':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@vscode/python-extension':
         specifier: ^1.0.5
         version: 1.0.6
@@ -327,9 +330,6 @@ importers:
       '@types/vscode':
         specifier: ^1.101.0
         version: 1.125.0
-      '@vscode/python-environments':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2


### PR DESCRIPTION
The implementation adds support for the new Python Environments API when the setting `"python.useEnvironmentsExtension"` is enabled. Ensures that the basedpyright extension correctly reads the active Python environment, aligning its behavior with that of Pylance and addressing  #1855.

The ms-python.vscode-python-envs API interfaces are defined to avoid importing the api and having it as a dependency. This would fail if the pyhton-envs extension is uninstalled and I think also when its deactivated.

I use some [python-test-fixtures](https://github.com/Weidav/uv-auto-venv/tree/main/test-fixtures) in my extension, which make it easier to manually (an also automatically) test the extension. It's basically some different typo of python projects whit different dependencies, so missing or failed imports are quickly identifiable. Are you interested to add them to your tests/repo?