### PR TITLE
fix CPython docString Display

### DIFF
--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -19,8 +19,8 @@ import { cleanAndSplitDocString } from './docStringUtils';
 // The restructured npm library was evaluated, and while it worked well for
 // parsing valid input, it was going to be more difficult to handle invalid
 // RST input.
-export function convertDocStringToMarkdown(docString: string): string {
-    return new DocStringConverter(docString).convert();
+export function convertDocStringToMarkdown(docString: string, forceLiteral = false): string {
+    return new DocStringConverter(docString, forceLiteral).convert();
 }
 
 //  Converts a docstring to a plaintext, human readable form. This will
@@ -126,10 +126,14 @@ class DocStringConverter {
     private _tableState: RestTableState | undefined;
     private _lastBacktickString: string | undefined;
 
-    constructor(input: string) {
+    private _forceLiteral: boolean;
+    private _lastLineWasPlainText = false;
+
+    constructor(input: string, forceLiteral = false) {
         this._state = this._parseText;
         this._input = input;
         this._lines = cleanAndSplitDocString(input);
+        this._forceLiteral = forceLiteral;
     }
 
     convert(): string {
@@ -258,7 +262,13 @@ class DocStringConverter {
 
         const line = this._formatPlainTextIndent(this._currentLine());
 
+        if (this._forceLiteral && this._lastLineWasPlainText) {
+            this._convertTrailingSoftLineBreak();
+        }
+
         this._appendTextLine(line);
+        // Must come after _appendTextLine, which resets the flag on entry.
+        this._lastLineWasPlainText = true;
         this._eatLine();
     }
 
@@ -267,23 +277,12 @@ class DocStringConverter {
         const prevIndent = this._prevIndent();
         const currIndent = this._currentIndent();
 
-        if (
-            currIndent > prevIndent &&
-            !_isUndefinedOrWhitespace(prev) &&
-            !this._builder.endsWith(MarkdownLineBreak) &&
-            !this._builder.endsWith('\n\n') &&
-            !_isHeader(prev)
-        ) {
-            this._builder = this._builder.slice(0, -1) + MarkdownLineBreak;
+        if (currIndent > prevIndent && !_isUndefinedOrWhitespace(prev) && !_isHeader(prev)) {
+            this._convertTrailingSoftLineBreak();
         }
 
-        if (
-            prevIndent > currIndent &&
-            !_isUndefinedOrWhitespace(prev) &&
-            !this._builder.endsWith(MarkdownLineBreak) &&
-            !this._builder.endsWith('\n\n')
-        ) {
-            this._builder = this._builder.slice(0, -1) + MarkdownLineBreak;
+        if (prevIndent > currIndent && !_isUndefinedOrWhitespace(prev)) {
+            this._convertTrailingSoftLineBreak();
         }
 
         if (prevIndent === 0 || this._builder.endsWith(MarkdownLineBreak) || this._builder.endsWith('\n\n')) {
@@ -292,6 +291,16 @@ class DocStringConverter {
             line = line.trimStart();
         }
         return line;
+    }
+
+    private _convertTrailingSoftLineBreak(): void {
+        if (
+            this._builder.endsWith('\n') &&
+            !this._builder.endsWith(MarkdownLineBreak) &&
+            !this._builder.endsWith('\n\n')
+        ) {
+            this._builder = this._builder.slice(0, -1) + MarkdownLineBreak;
+        }
     }
 
     private _convertIndent(line: string) {
@@ -308,6 +317,8 @@ class DocStringConverter {
     }
 
     private _appendTextLine(line: string): void {
+        this._lastLineWasPlainText = false;
+
         line = this._preprocessTextLine(line);
 
         const parts = line.split('`');
@@ -841,6 +852,8 @@ class DocStringConverter {
     }
 
     private _appendLine(line?: string): void {
+        this._lastLineWasPlainText = false;
+
         if (!_isUndefinedOrWhitespace(line)) {
             this._builder += line + '\n';
             this._skipAppendEmptyLine = false;

--- a/packages/pyright-internal/src/analyzer/docStringConversion.ts
+++ b/packages/pyright-internal/src/analyzer/docStringConversion.ts
@@ -126,14 +126,12 @@ class DocStringConverter {
     private _tableState: RestTableState | undefined;
     private _lastBacktickString: string | undefined;
 
-    private _forceLiteral: boolean;
     private _lastLineWasPlainText = false;
 
-    constructor(input: string, forceLiteral = false) {
+    constructor(input: string, private _forceLiteral = false) {
         this._state = this._parseText;
         this._input = input;
         this._lines = cleanAndSplitDocString(input);
-        this._forceLiteral = forceLiteral;
     }
 
     convert(): string {

--- a/packages/pyright-internal/src/common/docStringService.ts
+++ b/packages/pyright-internal/src/common/docStringService.ts
@@ -93,5 +93,5 @@ function _wrapInLiteralCodeBlock(content: string): string {
     }
     const fenceLength = Math.max(3, maxRun + 1);
     const fence = '`'.repeat(fenceLength);
-    return fence + 'text\n' + content + '\n' + fence;
+    return fence + '\n' + content + '\n' + fence;
 }

--- a/packages/pyright-internal/src/common/docStringService.ts
+++ b/packages/pyright-internal/src/common/docStringService.ts
@@ -9,6 +9,7 @@
 import { MarkupKind } from 'vscode-languageserver-types';
 import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../analyzer/docStringConversion';
 import {
+    cleanAndSplitDocString,
     extractAttributeDocumentation,
     extractParameterDocumentation,
     extractReturnDocumentation,
@@ -55,7 +56,11 @@ export class PyrightDocStringService implements DocStringService {
         return convertDocStringToPlainText(docString);
     }
 
-    convertDocStringToMarkdown(docString: string, _forceLiteral?: boolean, _sourceFileUri?: Uri): string {
+    convertDocStringToMarkdown(docString: string, forceLiteral?: boolean, _sourceFileUri?: Uri): string {
+        if (forceLiteral) {
+            const cleaned = cleanAndSplitDocString(docString).join('\n');
+            return _wrapInLiteralCodeBlock(cleaned);
+        }
         return convertDocStringToMarkdown(docString);
     }
 
@@ -75,4 +80,18 @@ export class PyrightDocStringService implements DocStringService {
         // No need to clone, no internal state
         return this;
     }
+}
+
+const backtickRunRegExp = /`+/g;
+
+function _wrapInLiteralCodeBlock(content: string): string {
+    let maxRun = 0;
+    for (const m of content.matchAll(backtickRunRegExp)) {
+        if (m[0].length > maxRun) {
+            maxRun = m[0].length;
+        }
+    }
+    const fenceLength = Math.max(3, maxRun + 1);
+    const fence = '`'.repeat(fenceLength);
+    return fence + 'text\n' + content + '\n' + fence;
 }

--- a/packages/pyright-internal/src/common/docStringService.ts
+++ b/packages/pyright-internal/src/common/docStringService.ts
@@ -58,8 +58,8 @@ export class PyrightDocStringService implements DocStringService {
 
     convertDocStringToMarkdown(docString: string, forceLiteral?: boolean, _sourceFileUri?: Uri): string {
         if (forceLiteral) {
-            const cleaned = cleanAndSplitDocString(docString).join('\n');
-            return _wrapInLiteralCodeBlock(cleaned);
+            const cleaned = cleanAndSplitDocString(docString).join('\n\n');
+          return convertDocStringToMarkdown(cleaned);
         }
         return convertDocStringToMarkdown(docString);
     }
@@ -80,18 +80,4 @@ export class PyrightDocStringService implements DocStringService {
         // No need to clone, no internal state
         return this;
     }
-}
-
-const backtickRunRegExp = /`+/g;
-
-function _wrapInLiteralCodeBlock(content: string): string {
-    let maxRun = 0;
-    for (const m of content.matchAll(backtickRunRegExp)) {
-        if (m[0].length > maxRun) {
-            maxRun = m[0].length;
-        }
-    }
-    const fenceLength = Math.max(3, maxRun + 1);
-    const fence = '`'.repeat(fenceLength);
-    return fence + 'text\n' + content + '\n' + fence;
 }

--- a/packages/pyright-internal/src/common/docStringService.ts
+++ b/packages/pyright-internal/src/common/docStringService.ts
@@ -93,5 +93,5 @@ function _wrapInLiteralCodeBlock(content: string): string {
     }
     const fenceLength = Math.max(3, maxRun + 1);
     const fence = '`'.repeat(fenceLength);
-    return fence + '\n' + content + '\n' + fence;
+    return fence + 'text\n' + content + '\n' + fence;
 }

--- a/packages/pyright-internal/src/common/docStringService.ts
+++ b/packages/pyright-internal/src/common/docStringService.ts
@@ -9,7 +9,6 @@
 import { MarkupKind } from 'vscode-languageserver-types';
 import { convertDocStringToMarkdown, convertDocStringToPlainText } from '../analyzer/docStringConversion';
 import {
-    cleanAndSplitDocString,
     extractAttributeDocumentation,
     extractParameterDocumentation,
     extractReturnDocumentation,
@@ -57,11 +56,7 @@ export class PyrightDocStringService implements DocStringService {
     }
 
     convertDocStringToMarkdown(docString: string, forceLiteral?: boolean, _sourceFileUri?: Uri): string {
-        if (forceLiteral) {
-            const cleaned = cleanAndSplitDocString(docString).join('\n\n');
-          return convertDocStringToMarkdown(cleaned);
-        }
-        return convertDocStringToMarkdown(docString);
+        return convertDocStringToMarkdown(docString, forceLiteral);
     }
 
     extractParameterDocumentation(functionDocString: string, paramName: string): string | undefined {

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -448,7 +448,7 @@ ${singleTick}FooBar${singleTick} is interesting.
     });
 
     test('CodeBlockDirective', () => {
-        const docstring = `Take a look at this 
+        const docstring = `Take a look at this
     .. code-block:: Python
 
     if foo:
@@ -1116,35 +1116,35 @@ Remote Python Call (RPyC)
         _testConvertToMarkdown(docstring, markdown);
     });
 
-    test('ForceLiteralWrapsInCodeBlock', () => {
+    test('ForceLiteralUsesParagraphBreaks', () => {
         const docstring = `Summary line.
 
 Extended description that spans
 multiple lines.
 `;
 
-        const markdown = '```text\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
+        const markdown = 'Summary line.\n\nExtended description that spans\n\nmultiple lines.';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralStripsCommonIndent', () => {
         const docstring = 'Header line\n    indented\n        deeper indent\n';
-        const markdown = '```text\n' + 'Header line\nindented\n    deeper indent' + '\n```';
+        const markdown = 'Header line\n\nindented\n\n&nbsp;&nbsp;&nbsp;&nbsp;deeper indent';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralEmptyDocstring', () => {
         const docstring = '';
-        const markdown = '```text\n\n```';
+        const markdown = '';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralWhitespaceOnlyDocstring', () => {
         const docstring = '\n   \n';
-        const markdown = '```text\n\n```';
+        const markdown = '';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1156,8 +1156,8 @@ multiple lines.
         _testConvertToMarkdown(docstring, markdown);
     });
 
-    test('ForceLiteralPreservesMarkupVerbatim', () => {
-        // The literal path must not run the reST/markup converter.
+    test('ForceLiteralConvertsMarkupToMarkdown', () => {
+        // The newline-based path still runs the normal Markdown converter.
         const docstring = [
             'Does **bold** and `inline` survive?',
             '',
@@ -1165,7 +1165,13 @@ multiple lines.
             '**Note:** `code` stays as-is.',
         ].join('\n');
 
-        const markdown = '```text\n' + docstring + '\n```';
+        const markdown = [
+            'Does \\*\\*bold\\*\\* and `inline` survive?',
+            '',
+            ':param x: some param',
+            '',
+            '\\*\\*Note:\\*\\* `code` stays as-is.',
+        ].join('\n');
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1174,12 +1180,12 @@ multiple lines.
         // Tabs expand to 4 spaces; carriage returns are stripped; common indent is removed.
         const docstring = 'Summary:\r\n    param: value\r\n\tTabbed line\r\n';
 
-        const markdown = '```text\n' + 'Summary:\nparam: value\n    Tabbed line' + '\n```';
+        const markdown = 'Summary:\n\nparam: value\n\n&nbsp;&nbsp;&nbsp;&nbsp;Tabbed line';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
-    test('ForceLiteralEscapesNestedBackticks', () => {
+    test('ForceLiteralPreservesNestedCodeBlock', () => {
         const docstring = [
             'Summary line.',
             '',
@@ -1193,25 +1199,25 @@ multiple lines.
         ].join('\n');
 
         const markdown = [
-            '````text',
             'Summary line.',
             '',
             'Example:',
             '',
             '```python',
+            '',
             'x = 1',
+            '',
             '```',
             '',
             'Trailing prose with `inline code`.',
-            '````',
         ].join('\n');
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
-    test('ForceLiteralEscapesFourBackticks', () => {
+    test('ForceLiteralConvertsDoubleBackticks', () => {
         const docstring = 'Has a ```` nested fence.';
-        const markdown = '`````text\n' + 'Has a ```` nested fence.' + '\n`````';
+        const markdown = 'Has a `` nested fence.';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -1123,28 +1123,28 @@ Extended description that spans
 multiple lines.
 `;
 
-        const markdown = '```\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
+        const markdown = '```text\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralStripsCommonIndent', () => {
         const docstring = 'Header line\n    indented\n        deeper indent\n';
-        const markdown = '```\n' + 'Header line\nindented\n    deeper indent' + '\n```';
+        const markdown = '```text\n' + 'Header line\nindented\n    deeper indent' + '\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralEmptyDocstring', () => {
         const docstring = '';
-        const markdown = '```\n\n```';
+        const markdown = '```text\n\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralWhitespaceOnlyDocstring', () => {
         const docstring = '\n   \n';
-        const markdown = '```\n\n```';
+        const markdown = '```text\n\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1165,7 +1165,7 @@ multiple lines.
             '**Note:** `code` stays as-is.',
         ].join('\n');
 
-        const markdown = '```\n' + docstring + '\n```';
+        const markdown = '```text\n' + docstring + '\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1174,7 +1174,7 @@ multiple lines.
         // Tabs expand to 8 spaces; carriage returns are stripped; common indent is removed.
         const docstring = 'Summary:\r\n    param: value\r\n\tTabbed line\r\n';
 
-        const markdown = '```\n' + 'Summary:\nparam: value\n    Tabbed line' + '\n```';
+        const markdown = '```text\n' + 'Summary:\nparam: value\n    Tabbed line' + '\n```';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1193,7 +1193,7 @@ multiple lines.
         ].join('\n');
 
         const markdown = [
-            '````',
+            '````text',
             'Summary line.',
             '',
             'Example:',
@@ -1211,7 +1211,7 @@ multiple lines.
 
     test('ForceLiteralEscapesFourBackticks', () => {
         const docstring = 'Has a ```` nested fence.';
-        const markdown = '`````\n' + 'Has a ```` nested fence.' + '\n`````';
+        const markdown = '`````text\n' + 'Has a ```` nested fence.' + '\n`````';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -1116,6 +1116,82 @@ Remote Python Call (RPyC)
 
         _testConvertToMarkdown(docstring, markdown);
     });
+
+    test('ForceLiteralWrapsInCodeBlock', () => {
+        const docstring = `Summary line.
+
+Extended description that spans
+multiple lines.
+`;
+
+        const expected = '```text\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
+
+    test('ForceLiteralStripsCommonIndent', () => {
+        const docstring = 'Header line\n    indented\n        deeper indent\n';
+        const expected = '```text\n' + 'Header line\nindented\n    deeper indent' + '\n```';
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
+
+    test('ForceLiteralEmptyDocstring', () => {
+        const docstring = '';
+        const expected = '```text\n\n```';
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
+
+    test('ForceLiteralDefaultIsFalse', () => {
+        const docstring = 'A\nB';
+        const expected = 'A\nB';
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
+
+    test('ForceLiteralEscapesNestedBackticks', () => {
+        const docstring = [
+            'Summary line.',
+            '',
+            'Example:',
+            '',
+            '```python',
+            'x = 1',
+            '```',
+            '',
+            'Trailing prose with `inline code`.',
+        ].join('\n');
+
+        const expected = [
+            '````text',
+            'Summary line.',
+            '',
+            'Example:',
+            '',
+            '```python',
+            'x = 1',
+            '```',
+            '',
+            'Trailing prose with `inline code`.',
+            '````',
+        ].join('\n');
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
+
+    test('ForceLiteralEscapesFourBackticks', () => {
+        const docstring = 'Has a ```` nested fence.';
+        const expected = '`````text\n' + 'Has a ```` nested fence.' + '\n`````';
+
+        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
+        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+    });
 }
 
 describe('Doc String Conversion', () => {

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -1064,9 +1064,8 @@ dtype : str, np.dtype, or ExtensionDtype, optional
         _testConvertToMarkdown(docstring, markdown);
     });
 
-    function _testConvertToMarkdown(docstring: string, expectedMarkdown: string) {
-        const actualMarkdown = docStringService.convertDocStringToMarkdown(docstring);
-
+    function _testConvertToMarkdown(docstring: string, expectedMarkdown: string, forceLiteral?: boolean) {
+        const actualMarkdown = docStringService.convertDocStringToMarkdown(docstring, forceLiteral);
         assert.equal(_normalizeLineEndings(actualMarkdown).trim(), _normalizeLineEndings(expectedMarkdown).trim());
     }
 
@@ -1124,34 +1123,60 @@ Extended description that spans
 multiple lines.
 `;
 
-        const expected = '```text\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
+        const markdown = '```\n' + 'Summary line.\n\nExtended description that spans\nmultiple lines.' + '\n```';
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralStripsCommonIndent', () => {
         const docstring = 'Header line\n    indented\n        deeper indent\n';
-        const expected = '```text\n' + 'Header line\nindented\n    deeper indent' + '\n```';
+        const markdown = '```\n' + 'Header line\nindented\n    deeper indent' + '\n```';
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralEmptyDocstring', () => {
         const docstring = '';
-        const expected = '```text\n\n```';
+        const markdown = '```\n\n```';
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralWhitespaceOnlyDocstring', () => {
+        const docstring = '\n   \n';
+        const markdown = '```\n\n```';
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralDefaultIsFalse', () => {
         const docstring = 'A\nB';
-        const expected = 'A\nB';
+        const markdown = 'A\nB';
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown);
+    });
+
+    test('ForceLiteralPreservesMarkupVerbatim', () => {
+        // The literal path must not run the reST/markup converter.
+        const docstring = [
+            'Does **bold** and `inline` survive?',
+            '',
+            ':param x: some param',
+            '**Note:** `code` stays as-is.',
+        ].join('\n');
+
+        const markdown = '```\n' + docstring + '\n```';
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralHandlesTabsAndCarriageReturns', () => {
+        // Tabs expand to 8 spaces; carriage returns are stripped; common indent is removed.
+        const docstring = 'Summary:\r\n    param: value\r\n\tTabbed line\r\n';
+
+        const markdown = '```\n' + 'Summary:\nparam: value\n    Tabbed line' + '\n```';
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralEscapesNestedBackticks', () => {
@@ -1167,8 +1192,8 @@ multiple lines.
             'Trailing prose with `inline code`.',
         ].join('\n');
 
-        const expected = [
-            '````text',
+        const markdown = [
+            '````',
             'Summary line.',
             '',
             'Example:',
@@ -1181,16 +1206,14 @@ multiple lines.
             '````',
         ].join('\n');
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralEscapesFourBackticks', () => {
         const docstring = 'Has a ```` nested fence.';
-        const expected = '`````text\n' + 'Has a ```` nested fence.' + '\n`````';
+        const markdown = '`````\n' + 'Has a ```` nested fence.' + '\n`````';
 
-        const actual = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ true);
-        assert.equal(_normalizeLineEndings(actual).trim(), _normalizeLineEndings(expected).trim());
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 }
 

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -1171,7 +1171,7 @@ multiple lines.
     });
 
     test('ForceLiteralHandlesTabsAndCarriageReturns', () => {
-        // Tabs expand to 8 spaces; carriage returns are stripped; common indent is removed.
+        // Tabs expand to 4 spaces; carriage returns are stripped; common indent is removed.
         const docstring = 'Summary:\r\n    param: value\r\n\tTabbed line\r\n';
 
         const markdown = '```text\n' + 'Summary:\nparam: value\n    Tabbed line' + '\n```';

--- a/packages/pyright-internal/src/tests/docStringConversion.test.ts
+++ b/packages/pyright-internal/src/tests/docStringConversion.test.ts
@@ -1069,6 +1069,8 @@ dtype : str, np.dtype, or ExtensionDtype, optional
         assert.equal(_normalizeLineEndings(actualMarkdown).trim(), _normalizeLineEndings(expectedMarkdown).trim());
     }
 
+    const hardBreak = '  \n';
+
     function _testConvertToPlainText(docstring: string, expectedPlainText: string) {
         const actualMarkdown = docStringService.convertDocStringToPlainText(docstring);
 
@@ -1123,14 +1125,17 @@ Extended description that spans
 multiple lines.
 `;
 
-        const markdown = 'Summary line.\n\nExtended description that spans\n\nmultiple lines.';
+        const markdown = 'Summary line.\n\n' + 'Extended description that spans' + hardBreak + 'multiple lines.';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralStripsCommonIndent', () => {
         const docstring = 'Header line\n    indented\n        deeper indent\n';
-        const markdown = 'Header line\n\nindented\n\n&nbsp;&nbsp;&nbsp;&nbsp;deeper indent';
+
+        // Common indent (4) is removed; surviving relative indent renders as&nbsp;-prefixed
+        // text joined by hard breaks instead of paragraph breaks.
+        const markdown = 'Header line' + hardBreak + 'indented' + hardBreak + '&nbsp;&nbsp;&nbsp;&nbsp;deeper indent';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1157,7 +1162,9 @@ multiple lines.
     });
 
     test('ForceLiteralConvertsMarkupToMarkdown', () => {
-        // The newline-based path still runs the normal Markdown converter.
+        // The converter still runs, so inline code is preserved and markdown chars escaped;
+        // the `**Note:**` line is itself claimed by the field-list catch-all (it matches
+        // `name: value`), which forces a preceding break — so no hard break is welded on.
         const docstring = [
             'Does **bold** and `inline` survive?',
             '',
@@ -1168,19 +1175,19 @@ multiple lines.
         const markdown = [
             'Does \\*\\*bold\\*\\* and `inline` survive?',
             '',
-            ':param x: some param',
-            '',
-            '\\*\\*Note:\\*\\* `code` stays as-is.',
+            ':param x: some param' + hardBreak + '\\*\\*Note:\\*\\* `code` stays as-is.',
         ].join('\n');
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
 
     test('ForceLiteralHandlesTabsAndCarriageReturns', () => {
-        // Tabs expand to 4 spaces; carriage returns are stripped; common indent is removed.
+        // Carriage returns are stripped; removing the common indent leaves 4 spaces from the expanded tab.
+        // The `param: value` line is claimed by the field-list path (which forces its own breaks);
+        // the tab-indented line goes through the plain-text path with nbsp indent.
         const docstring = 'Summary:\r\n    param: value\r\n\tTabbed line\r\n';
 
-        const markdown = 'Summary:\n\nparam: value\n\n&nbsp;&nbsp;&nbsp;&nbsp;Tabbed line';
+        const markdown = 'Summary:' + hardBreak + 'param: value' + hardBreak + '&nbsp;&nbsp;&nbsp;&nbsp;Tabbed line';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
     });
@@ -1204,9 +1211,7 @@ multiple lines.
             'Example:',
             '',
             '```python',
-            '',
             'x = 1',
-            '',
             '```',
             '',
             'Trailing prose with `inline code`.',
@@ -1220,6 +1225,67 @@ multiple lines.
         const markdown = 'Has a `` nested fence.';
 
         _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralPreservesPlainTextLayout', () => {
+        const docstring = [
+            'First line.',
+            'Second line.',
+            'Third line.',
+            '',
+            'Example:',
+            '    Indented line.',
+            '        Deeper line.',
+        ].join('\n');
+
+        const markdown =
+            ['First line.', 'Second line.', 'Third line.'].join(hardBreak) +
+            '\n\n' +
+            ['Example:', '&nbsp;&nbsp;&nbsp;&nbsp;Indented line.', '&nbsp;'.repeat(8) + 'Deeper line.'].join(hardBreak);
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralBlankLineStaysParagraphBreak', () => {
+        const docstring = 'Summary.\n\nLine one\nLine two\n';
+
+        const markdown = 'Summary.\n\n' + 'Line one' + hardBreak + 'Line two';
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralDoctestStaysOneBlock', () => {
+        const docstring = '>>> x = 1\n>>> x + 1\n2\n';
+
+        const markdown = ['```', '>>> x = 1', '>>> x + 1', '2', '```'].join('\n');
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralFencedCodeBlockUnchanged', () => {
+        const docstring = ['```python', 'x = 1', 'print(x)', '```'].join('\n');
+
+        const markdown = ['```python', 'x = 1', 'print(x)', '```'].join('\n');
+
+        _testConvertToMarkdown(docstring, markdown, /* forceLiteral */ true);
+    });
+
+    test('ForceLiteralExplicitFalseMatchesDefault', () => {
+        const docstring = [
+            'super() -> same as super(__class__, <first argument>)',
+            'super(type) -> unbound super object',
+        ].join('\n');
+
+        const withExplicitFalse = docStringService.convertDocStringToMarkdown(docstring, /* forceLiteral */ false);
+        const withDefault = docStringService.convertDocStringToMarkdown(docstring);
+        assert.equal(withExplicitFalse, withDefault);
+        assert.equal(
+            _normalizeLineEndings(withDefault).trim(),
+            [
+                'super() -&gt; same as super(\\_\\_class\\_\\_, &lt;first argument&gt;)',
+                'super(type) -&gt; unbound super object',
+            ].join('\n')
+        );
     });
 }
 

--- a/packages/pyright-internal/src/tests/hoverProvider.test.ts
+++ b/packages/pyright-internal/src/tests/hoverProvider.test.ts
@@ -602,7 +602,7 @@ test('TypedDict doc string', async () => {
     state.openFile(marker1.fileName);
 
     state.verifyHover('markdown', {
-        marker: '```python\n(class) TypedDict\n```\n---\n```\nA simple typed namespace. At runtime it is equivalent to a plain dict.\n```',
+        marker: '```python\n(class) TypedDict\n```\n---\n```text\nA simple typed namespace. At runtime it is equivalent to a plain dict.\n```',
     });
 });
 

--- a/packages/pyright-internal/src/tests/hoverProvider.test.ts
+++ b/packages/pyright-internal/src/tests/hoverProvider.test.ts
@@ -602,7 +602,7 @@ test('TypedDict doc string', async () => {
     state.openFile(marker1.fileName);
 
     state.verifyHover('markdown', {
-        marker: '```python\n(class) TypedDict\n```\n---\n```text\nA simple typed namespace. At runtime it is equivalent to a plain dict.\n```',
+        marker: '```python\n(class) TypedDict\n```\n---\nA simple typed namespace. At runtime it is equivalent to a plain dict.',
     });
 });
 

--- a/packages/pyright-internal/src/tests/hoverProvider.test.ts
+++ b/packages/pyright-internal/src/tests/hoverProvider.test.ts
@@ -602,7 +602,7 @@ test('TypedDict doc string', async () => {
     state.openFile(marker1.fileName);
 
     state.verifyHover('markdown', {
-        marker: '```python\n(class) TypedDict\n```\n---\nA simple typed namespace. At runtime it is equivalent to a plain dict.',
+        marker: '```python\n(class) TypedDict\n```\n---\n```\nA simple typed namespace. At runtime it is equivalent to a plain dict.\n```',
     });
 });
 


### PR DESCRIPTION
### Description/Problem

This PR aims to solve the problem of docString display, when we hover a CPython stdlib symbol.
The lines, even though have newLine indications ("\n"), cannot separate.

This happens on both Zed and VSCode.

This is the part of #1790.

### Demo

The below demo is demostrated using Zed:

| Before | After |
| ----- | ----- |
| <img width="494" height="305" alt="Screenshot 2026-08-15 at 16 38 40" src="https://github.com/user-attachments/assets/ebd93300-35df-4af0-b901-0e2dc9a43ee8" /> | <img width="494" height="305" alt="Screenshot 2026-08-15 at 16 22 30" src="https://github.com/user-attachments/assets/0c61820c-ea2e-4bdb-8677-79316e5fc913" /> |

Please feel free to let me know if there are any problems/concerns.