### PR TITLE
remove redundant `setup-python` actions from ci 

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -89,9 +89,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        id: install_python
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         name: download docstubs
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,10 +36,6 @@ jobs:
         with:
           fetch-depth: 0 # fetch all commits/branches
           persist-credentials: true # required to push changes
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        id: install_python
-        with:
-          python-version: 3.12
       - name: Configure Git user
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/mypy_primer_pr.yaml
+++ b/.github/workflows/mypy_primer_pr.yaml
@@ -55,7 +55,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       - name: add gg aliases to PATH
         run: |
           cd pyright_to_test

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: remove this, see TODO below about the venv steps
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         id: install_python
 


### PR DESCRIPTION
python versions are now 100% managed by uv