### PR TITLE
Improve monospaced link contrast

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,12 @@
 .md-grid {
     max-width: 1600px;
 }
+
+body:not([data-md-color-scheme="slate"]) {
+    a:has(code) {
+        --md-typeset-a-color: hsl(35, 100%, 30%);
+        code {
+            background-color: hsl(35, 70%, 93%);
+        }
+    }
+}


### PR DESCRIPTION
Zensical's `amber` colors (and some other default color choices) have poor contrast and don't pass WCAG requirements (and are sometimes just difficult to read).

This PR fixes the worst issue which is links that are also monospaced text.

Before: 
<img width="670" height="90" alt="image" src="https://github.com/user-attachments/assets/5991f673-ce22-4285-a951-8bc3b9e1a316" />

After:
<img width="657" height="90" alt="image" src="https://github.com/user-attachments/assets/162d15ff-28d1-4779-be01-cf224e75843a" />
